### PR TITLE
fix: increase ESP32 boot delay to 1500ms and flush stray byte on Serial startup

### DIFF
--- a/firmware/moen_kiln/moen_kiln.ino
+++ b/firmware/moen_kiln/moen_kiln.ino
@@ -105,9 +105,10 @@ void setup() {
   // matrixBegin() wakes the ESP32-S3; call it before Serial.begin() so
   // boot bytes are discarded rather than forwarded to the Serial Monitor
   matrixBegin();
-  delay(1000);
+  delay(1500);
 
   Serial.begin(115200);
+  Serial.println();
 
   pinMode(LEDR, OUTPUT); digitalWrite(LEDR, HIGH);  // aktiv lav – start av
   pinMode(LEDG, OUTPUT); digitalWrite(LEDG, HIGH);


### PR DESCRIPTION
Closes #19

Increases `delay()` after `matrixBegin()` from 1000ms to 1500ms to give the ESP32-S3 co-processor more time to finish its handshake burst before USB CDC opens. Adds a bare `Serial.println()` as the first Serial call so any stray byte that survives the timing window lands on its own line, allowing the terminal's UTF-8 parser to recover before the banner is printed.