### PR TITLE
feat: button timings – 2s=Glaze, 10s=Config Test

### DIFF
--- a/firmware/moen_kiln/moen_kiln.ino
+++ b/firmware/moen_kiln/moen_kiln.ino
@@ -634,7 +634,7 @@ void checkStartButton() {
     matrixClear();  // tøm skjermen umiddelbart ved ethvert trykk
 
     if (kilnState == IDLE) {
-      Serial.println(F("Button: pressed (hold 1s=Glaze, 5s=Bisque)"));
+      Serial.println(F("Button: pressed (hold 2s=Glaze, 10s=ConfigTest)"));
       showingIP = false;
     } else if (kilnState == RAMPING || kilnState == HOLDING || kilnState == FREE_COOL) {
       displayScreen = (displayScreen + 1) % 4;
@@ -643,19 +643,18 @@ void checkStartButton() {
     }
   }
 
-  // Hold i IDLE: 1 s = Glaze klar, 5 s = Bisque
+  // Hold i IDLE: 2 s = Glaze klar, 10 s = Config Test
   if (holdStart > 0 && kilnState == IDLE) {
     unsigned long held = now - holdStart;
     cancelHeld = true;
-    drawCancelCountdown(min(1.0f, (float)held / 5000.0f));
-    if (!glazeArmed && held >= 1000) {
+    drawCancelCountdown(min(1.0f, (float)held / 10000.0f));
+    if (!glazeArmed && held >= 2000) {
       glazeArmed = true;
-
     }
-    if (held >= 5000) {
+    if (held >= 10000) {
       cancelHeld = false; glazeArmed = false; holdStart = 0;
       showingIP = false;
-      if (!sensorMissing) startProfile(&PROFILES[1]);  // Bisque
+      if (!sensorMissing) startProfile(&PROFILES[2]);  // Config Test
     }
   }
 


### PR DESCRIPTION
## Summary

- Hold **2 s** → Glaze armed; release to start
- Hold **10 s** → Config Test starts automatically
- Cancel during active firing (5 s hold) unchanged

Replaces the old 1 s / 5 s Glaze / Bisque mapping.

## Changes

- `moen_kiln.ino` — `checkStartButton()`: thresholds updated, `PROFILES[1]` → `PROFILES[2]`, countdown scale 5000 → 10000 ms, serial help text updated

## Test plan

- [ ] Hold 2 s in IDLE → release → Glaze starts
- [ ] Hold 10 s in IDLE → Config Test starts (refused if kiln > 40 °C)
- [ ] Hold < 2 s → nothing happens
- [ ] Hold 5 s during active firing → cancel countdown and stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)