### PR TITLE
fix: Config Test target 1220 °C → 800 °C

### DIFF
--- a/firmware/moen_kiln/profiles.h
+++ b/firmware/moen_kiln/profiles.h
@@ -32,7 +32,7 @@ static const Segment SEG_BISQUE[] = {
 
 // ── Config test: max speed to 1220 °C, then free cool to room temp ────────────
 static const Segment SEG_CONFIGTEST[] = {
-  { "Ramp Up",   1220, 9999, 0 },
+  { "Ramp Up",    800, 9999, 0 },
   { "Free Cool",   25,    0, 0 },
 };
 


### PR DESCRIPTION
Reduces max temp for calibration run. Per Ingar: 800 °C is safe for empty-kiln use, less thermal stress on refractory bricks than 1220 °C.