### PR TITLE
feat: unify CSV log columns and date-stamped downloads (#30)

### DIFF
--- a/firmware/moen_kiln/moen_kiln.ino
+++ b/firmware/moen_kiln/moen_kiln.ino
@@ -463,6 +463,12 @@ const char* eventStr(uint8_t t) {
   }
 }
 
+const char* segName(uint8_t rawIdx) {
+  uint8_t si = rawIdx & 0x7F;
+  if (profile && si < profile->segCount) return profile->segments[si].name;
+  return "";
+}
+
 void writeFullLogPoint(unsigned long now) {
   uint16_t idx = fullLogHead % FULL_LOG_SIZE;
   DataPoint& dp = fullLogBuf[idx];
@@ -909,7 +915,7 @@ void handleHTTP() {
     client.println(F("Content-Disposition: attachment; filename=\"detail-log.csv\""));
     client.println(F("Connection: close"));
     client.println();
-    client.println(F("sec,temp,setpoint,relay,duty_pct,seg_idx"));
+    client.println(F("sec,temp,setpoint,relay,duty_pct,comment"));
     uint16_t dstart = (logCount == LOG_SIZE) ? logHead % LOG_SIZE : 0;
     for (uint16_t i = 0; i < logCount; i++) {
       const DataPoint& dp = logBuf[(dstart + i) % LOG_SIZE];
@@ -918,7 +924,7 @@ void handleHTTP() {
       client.print(dp.sp); client.print(',');
       client.print((dp.segIdx & 0x80) ? 1 : 0); client.print(',');
       client.print(dp.pid); client.print(',');
-      client.println(dp.segIdx & 0x7F);
+      client.println(segName(dp.segIdx));
     }
 
   } else if (req.startsWith("GET /api/log.csv")) {
@@ -927,15 +933,14 @@ void handleHTTP() {
     client.println(F("Content-Disposition: attachment; filename=\"firing.csv\""));
     client.println(F("Connection: close"));
     client.println();
-    client.println(F("sec,temp,setpoint,relay,duty_pct,seg_idx,event"));
+    client.println(F("sec,temp,setpoint,relay,duty_pct,comment"));
     uint16_t fstart = (fullLogCount == FULL_LOG_SIZE) ? fullLogHead % FULL_LOG_SIZE : 0;
     uint8_t  ei = 0;
     for (uint16_t i = 0; i < fullLogCount; i++) {
       const DataPoint& dp = fullLogBuf[(fstart + i) % FULL_LOG_SIZE];
-      // Legg inn hendelser som skjedde før dette tidspunktet
       while (ei < eventCount && eventLog[ei].sec <= dp.sec) {
-        client.print(eventLog[ei].sec); client.print(F(","));
-        client.print(eventLog[ei].temp); client.print(F(",,,,,"));
+        client.print(eventLog[ei].sec); client.print(',');
+        client.print(eventLog[ei].temp); client.print(F(",,,,"));
         client.println(eventStr(eventLog[ei].type));
         ei++;
       }
@@ -944,12 +949,11 @@ void handleHTTP() {
       client.print(dp.sp); client.print(',');
       client.print((dp.segIdx & 0x80) ? 1 : 0); client.print(',');
       client.print(dp.pid); client.print(',');
-      client.print(dp.segIdx & 0x7F); client.println(',');
+      client.println(segName(dp.segIdx));
     }
-    // Resterende hendelser etter siste datapunkt
     while (ei < eventCount) {
-      client.print(eventLog[ei].sec); client.print(F(","));
-      client.print(eventLog[ei].temp); client.print(F(",,,,,"));
+      client.print(eventLog[ei].sec); client.print(',');
+      client.print(eventLog[ei].temp); client.print(F(",,,,"));
       client.println(eventStr(eventLog[ei].type));
       ei++;
     }

--- a/firmware/moen_kiln/web_ui.h
+++ b/firmware/moen_kiln/web_ui.h
@@ -95,8 +95,8 @@ details summary{cursor:pointer;color:#ff7700;font-size:.95em;touch-action:manipu
 <div class="card" id="logcard" style="padding:10px 8px">
   <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px">
     <span style="color:#ff7700;font-size:.88em;font-weight:700">Log</span>
-    <a href="/api/log.csv" style="text-decoration:none"><button class="rst" style="flex:0;padding:3px 10px;font-size:.78em">↓ Full log</button></a>
-    <a href="/api/detail.csv" style="text-decoration:none"><button class="rst" style="flex:0;padding:3px 10px;font-size:.78em;margin-left:4px">↓ Detail</button></a>
+    <button class="rst" style="flex:0;padding:3px 10px;font-size:.78em" onclick="dlCsv('/api/log.csv','firing')">↓ Full log</button>
+    <button class="rst" style="flex:0;padding:3px 10px;font-size:.78em;margin-left:4px" onclick="dlCsv('/api/detail.csv','detail')">↓ Detail</button>
     <button class="rst" style="flex:0;padding:3px 10px;font-size:.78em;margin-left:4px" onclick="refreshLog()">↻</button>
   </div>
   <div id="evtsec" style="margin-bottom:8px;display:none">
@@ -148,6 +148,7 @@ var cv=document.getElementById('cv'),cx=cv.getContext('2d'),T=[],SP=[];
 var sc={RAMP:'#ff7700',HOLD:'#44bb44',STOP:'#ff4444',ERR:'#ff4444',DONE:'#44bb44',IDLE:'#666',COOL:'#4499ff'};
 var sn={RAMP:'Heating up',HOLD:'Holding temperature',COOL:'Cooling down',DONE:'Complete',IDLE:'Ready',STOP:'Stopped',ERR:'Error'};
 var modalDismissed=false,lastFiringId=-1,segsData=[],openSeg=-1,logSegNames=[];
+function dlCsv(url,prefix){fetch(url).then(function(r){return r.blob();}).then(function(b){var a=document.createElement('a');a.href=URL.createObjectURL(b);a.download=prefix+'-'+new Date().toISOString().slice(0,10)+'.csv';a.click();URL.revokeObjectURL(a.href);});}
 function fmt(s){var h=Math.floor(s/3600),m=Math.floor((s%3600)/60);return h>0?h+'h '+m+'m':m+'m';}
 function dismiss(){
   document.getElementById('overlay').classList.remove('show');


### PR DESCRIPTION
## Summary

- Both CSV exports (`/api/log.csv` and `/api/detail.csv`) now share the same six-column schema: `sec,temp,setpoint,relay,duty_pct,comment`
- Replaced the raw `seg_idx` integer column with a human-readable `comment` column that holds the segment name (looked up via a new `segName()` helper); falls back to empty string if no profile is loaded
- Event rows in the full log use the same six columns — data fields are blank and the event description goes in `comment` (fixes the old trailing-comma bug and the inconsistent 7-column schema)
- Download buttons now use `fetch()` + Blob so the browser saves files with date-stamped names (`firing-YYYY-MM-DD.csv`, `detail-YYYY-MM-DD.csv`) instead of the hardcoded server filename

## Test plan

- [ ] Flash firmware and start a firing; download both CSVs and verify six columns in every row
- [ ] Confirm event rows in `firing-*.csv` have blank setpoint/relay/duty_pct and the event description in the `comment` column
- [ ] Verify segment names (e.g. "Glaze 1") appear in the `comment` column for data rows
- [ ] Check that saved filenames include today's date
- [ ] Open CSV in Excel/DBeaver and confirm no parse errors

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)