### PR TITLE
fix: QA pass — six bugs and cleanup issues (#36–#41)

### DIFF
--- a/firmware/moen_kiln/config.h
+++ b/firmware/moen_kiln/config.h
@@ -16,7 +16,7 @@
 #include "config_secrets.h"
 
 // ── Knapper ───────────────────────────────────────────────────────────────────
-#define PIN_BTN_START   5   // Start Glaze (hold 1s) / Bisque (hold 5s)
+#define PIN_BTN_START   5   // Start Glaze (hold 2s) / Bisque (hold 5s)
 
 // ── Data-logg ─────────────────────────────────────────────────────────────────
 #define LOG_SIZE             480         // detaljlogg: RAM, siste 2 timer (15 sek)
@@ -53,7 +53,6 @@ struct Event { uint16_t sec; uint8_t type; uint16_t temp; };
 
 // ── Sikkerhet ────────────────────────────────────────────────────────────────
 #define MAX_TEMP_C       1300.0f
-#define TEMP_DEVIATION   10.0f
 
 // ── EEPROM-layout ─────────────────────────────────────────────────────────────
 // E-post konfigurasjon

--- a/firmware/moen_kiln/moen_kiln.ino
+++ b/firmware/moen_kiln/moen_kiln.ino
@@ -112,20 +112,16 @@ void setup() {
   delay(1500);
 
   Serial.begin(115200);
-  Serial.println(F("DBG1"));
 
   pinMode(LEDR, OUTPUT); digitalWrite(LEDR, HIGH);  // aktiv lav – start av
   pinMode(LEDG, OUTPUT); digitalWrite(LEDG, HIGH);
   pinMode(LEDB, OUTPUT); digitalWrite(LEDB, HIGH);
-  Serial.println(F("DBG2"));
 
   pinMode(PIN_ESTOP, INPUT_PULLUP);
   attachInterrupt(digitalPinToInterrupt(PIN_ESTOP), onEstop, FALLING);
-  Serial.println(F("DBG3"));
 
   pinMode(PIN_BTN_START, INPUT_PULLUP);
   attachInterrupt(digitalPinToInterrupt(PIN_BTN_START), onBtnStart, FALLING);
-  Serial.println(F("DBG4"));
 
   Serial.println(F("=== Moen Kiln ==="));
   Serial.print(F("Pins: relay=")); Serial.print(PIN_RELAY);
@@ -273,6 +269,7 @@ void tickHolding() {
 void tickFreeCool() {
   pidOutput = 0;
   if (currentTemp <= profile->segments[segIdx].targetTemp + 5.0f) nextSegment();
+  checkAlarms();
 }
 
 void savePendingReport() {
@@ -674,7 +671,7 @@ void checkStartButton() {
     }
   }
 
-  // Hold i IDLE: 2 s = Glaze klar, 5 s = Config Test
+  // Hold i IDLE: 2 s = Glaze klar, 5 s = Bisque
   if (holdStart > 0 && kilnState == IDLE) {
     unsigned long held = now - holdStart;
     cancelHeld = true;
@@ -990,8 +987,8 @@ void handleHTTP() {
   } else if (req.startsWith("GET /api/history")) {
     httpOK(client, "application/json");
     client.print('[');
-    uint8_t start = (logCount == LOG_SIZE) ? logHead % LOG_SIZE : 0;
-    for (uint8_t i = 0; i < logCount; i++) {
+    uint16_t start = (logCount == LOG_SIZE) ? logHead % LOG_SIZE : 0;
+    for (uint16_t i = 0; i < logCount; i++) {
       const DataPoint& dp = logBuf[(start + i) % LOG_SIZE];
       if (i) client.print(',');
       client.print('['); client.print(dp.sec); client.print(',');
@@ -1126,7 +1123,7 @@ void startProfile(const Profile* p) {
   firingStartMs = millis();
   peakTemp = 0.0f; reportSent = false; manualRelay = false; matrixDone = false;
   testTimeoutMs = (strcmp(p->id, "configtest") == 0) ? firingStartMs + 4UL * 3600UL * 1000UL : 0;
-  profile = p; segIdx = 0; estopFlag = false; kilnState = RAMPING;
+  profile = p; segIdx = 0; estopFlag = false; estopAnnounced = false; kilnState = RAMPING;
   pidI = 0; pidLastMs = millis();
   // Vis første 4 tegn av profilnavn (f.eks. "GLAZ" / "BISQ")
   char word[5] = {0};


### PR DESCRIPTION
## Summary

Six issues found during the QA pass on issue #34, all resolved in one commit:

| Issue | Type | Fix |
|-------|------|-----|
| #36 | 🔴 Bug | `/api/history` `uint8_t` loop index silently truncated after 255 entries → `uint16_t` |
| #37 | 🟠 Bug | `estopAnnounced` not reset in `startProfile()` → second e-stop left state machine inconsistent |
| #38 | 🟠 Safety | `tickFreeCool()` missing `checkAlarms()` → max-temp exceeded during cooling not caught |
| #39 | 🟡 Cleanup | DBG1–DBG4 debug prints removed from `setup()` |
| #40 | 🟡 Cleanup | Stale comments updated: "hold 1s" → "hold 2s", "Config Test" → "Bisque" |
| #41 | 🟡 Cleanup | `TEMP_DEVIATION` constant removed (defined but never used) |

## Test plan

- [ ] Flash and verify clean serial output (no DBG1–4)
- [ ] Start a firing, let it run past 255 log points, download `/api/history` — verify all entries present
- [ ] Trigger e-stop, reset, start new firing, trigger e-stop again — verify kiln enters ESTOPPED state and event is logged
- [ ] Manually verify `checkAlarms()` is reachable during FREE_COOL phase

Closes #36, #37, #38, #39, #40, #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)