### PR TITLE
feat: JSON profile editor in web GUI with locked built-ins (closes #45)

### DIFF
--- a/firmware/moen_kiln/config.h
+++ b/firmware/moen_kiln/config.h
@@ -82,3 +82,16 @@ struct Event { uint16_t sec; uint8_t type; uint16_t temp; };
 #define EEPROM_ELOG_CNT   5302  // 1 byte
 #define EEPROM_ELOG_LOG   5303  // 32 * 5 bytes = 160 → slutter på 5463
 
+// Custom firing profiles (user-editable; default profiles are compile-time constants)  0x46 = valid
+#define MAX_CUSTOM_PROFILES    5
+#define MAX_SEGS_PER_PROFILE   8
+#define PROF_ID_LEN           15   // max chars for profile id (excl. null)
+#define PROF_NAME_LEN         15   // max chars for profile display name (excl. null)
+#define SEG_NAME_LEN          11   // max chars for segment name (excl. null)
+
+// StoredSegment: 18 bytes  |  StoredProfile: 1 + (PROF_ID_LEN+1) + (PROF_NAME_LEN+1) + 8*18 = 177 bytes
+// 5 profiles × 177 = 885 bytes → block ends at 5464 + 2 + 885 = 6351
+#define EEPROM_PROF_FLAG  5464  // 1 byte : 0x46 = custom profiles stored
+#define EEPROM_PROF_CNT   5465  // 1 byte : number of custom profiles (0–MAX_CUSTOM_PROFILES)
+#define EEPROM_PROF_DATA  5466  // MAX_CUSTOM_PROFILES * 177 bytes = 885 → ends at 6351
+

--- a/firmware/moen_kiln/custom_profiles.h
+++ b/firmware/moen_kiln/custom_profiles.h
@@ -1,0 +1,287 @@
+#pragma once
+#include <stdint.h>
+#include <string.h>
+#include <EEPROM.h>
+#include "config.h"
+#include "profiles.h"
+
+// ── Stored profile structs (mutable char arrays, EEPROM-serialisable) ─────────
+
+struct StoredSegment {
+  char     name[SEG_NAME_LEN + 1];  // 12 bytes
+  uint16_t targetTemp;               //  2 bytes
+  uint16_t ratePerHour;              //  2 bytes
+  uint16_t holdMin;                  //  2 bytes
+};                                   // 18 bytes total
+
+struct StoredProfile {
+  char          id  [PROF_ID_LEN   + 1];  // 16 bytes
+  char          name[PROF_NAME_LEN + 1];  // 16 bytes
+  uint8_t       segCount;                 //  1 byte
+  StoredSegment segs[MAX_SEGS_PER_PROFILE]; // 144 bytes
+};                                          // 177 bytes total
+
+// ── Runtime storage ────────────────────────────────────────────────────────────
+// Custom profiles live here; Profile/Segment wrappers point into these arrays.
+
+static StoredProfile  _customStore[MAX_CUSTOM_PROFILES];
+static Segment        _customSegArrays[MAX_CUSTOM_PROFILES][MAX_SEGS_PER_PROFILE];
+static Profile        _customProfileArr[MAX_CUSTOM_PROFILES];
+static uint8_t        _customCount = 0;
+
+// Public accessors (updated by rebuild functions below)
+const Profile* customProfiles     = nullptr;
+uint8_t        customProfileCount = 0;
+
+// ── Build Profile/Segment wrapper arrays from _customStore ────────────────────
+static void rebuildWrappers() {
+  for (uint8_t pi = 0; pi < _customCount; pi++) {
+    StoredProfile& sp = _customStore[pi];
+    for (uint8_t si = 0; si < sp.segCount; si++) {
+      _customSegArrays[pi][si].name        = sp.segs[si].name;
+      _customSegArrays[pi][si].targetTemp  = (float)sp.segs[si].targetTemp;
+      _customSegArrays[pi][si].ratePerHour = (float)sp.segs[si].ratePerHour;
+      _customSegArrays[pi][si].holdMin     = sp.segs[si].holdMin;
+    }
+    _customProfileArr[pi].id       = sp.id;
+    _customProfileArr[pi].name     = sp.name;
+    _customProfileArr[pi].segCount = sp.segCount;
+    _customProfileArr[pi].segments = _customSegArrays[pi];
+  }
+  customProfiles     = (_customCount > 0) ? _customProfileArr : nullptr;
+  customProfileCount = _customCount;
+}
+
+// ── EEPROM persistence ─────────────────────────────────────────────────────────
+void saveCustomProfiles() {
+  EEPROM.update(EEPROM_PROF_CNT, _customCount);
+  for (uint8_t i = 0; i < _customCount; i++)
+    EEPROM.put(EEPROM_PROF_DATA + (int)i * (int)sizeof(StoredProfile), _customStore[i]);
+  EEPROM.update(EEPROM_PROF_FLAG, 0x46);
+}
+
+void loadCustomProfiles() {
+  if (EEPROM.read(EEPROM_PROF_FLAG) != 0x46) { _customCount = 0; rebuildWrappers(); return; }
+  uint8_t cnt = EEPROM.read(EEPROM_PROF_CNT);
+  if (cnt > MAX_CUSTOM_PROFILES) cnt = 0;
+  _customCount = cnt;
+  for (uint8_t i = 0; i < cnt; i++)
+    EEPROM.get(EEPROM_PROF_DATA + (int)i * (int)sizeof(StoredProfile), _customStore[i]);
+  rebuildWrappers();
+}
+
+// ── JSON serialiser ────────────────────────────────────────────────────────────
+// Writes the full profiles JSON (default + custom) to a WiFiClient.
+// Default profiles are marked "builtin":true so the GUI can lock them.
+template<typename TClient>
+void sendProfilesJSON(TClient& client) {
+  client.print('[');
+  bool first = true;
+
+  // Built-in (read-only) profiles
+  for (uint8_t i = 0; i < PROFILE_COUNT; i++) {
+    if (!first) client.print(',');
+    first = false;
+    const Profile& p = PROFILES[i];
+    client.print(F("{\"id\":\""));   client.print(p.id);
+    client.print(F("\",\"name\":\"")); client.print(p.name);
+    client.print(F("\",\"builtin\":true,\"segments\":["));
+    for (uint8_t s = 0; s < p.segCount; s++) {
+      if (s) client.print(',');
+      const Segment& seg = p.segments[s];
+      client.print(F("{\"name\":\""));        client.print(seg.name);
+      client.print(F("\",\"targetTemp\":"));   client.print((int)seg.targetTemp);
+      client.print(F(",\"ratePerHour\":"));    client.print((int)seg.ratePerHour);
+      client.print(F(",\"holdMin\":"));        client.print(seg.holdMin);
+      client.print('}');
+    }
+    client.print(F("]}"));
+  }
+
+  // Custom (editable) profiles
+  for (uint8_t i = 0; i < _customCount; i++) {
+    client.print(',');
+    StoredProfile& sp = _customStore[i];
+    client.print(F("{\"id\":\""));   client.print(sp.id);
+    client.print(F("\",\"name\":\"")); client.print(sp.name);
+    client.print(F("\",\"builtin\":false,\"segments\":["));
+    for (uint8_t s = 0; s < sp.segCount; s++) {
+      if (s) client.print(',');
+      StoredSegment& seg = sp.segs[s];
+      client.print(F("{\"name\":\""));        client.print(seg.name);
+      client.print(F("\",\"targetTemp\":"));   client.print(seg.targetTemp);
+      client.print(F(",\"ratePerHour\":"));    client.print(seg.ratePerHour);
+      client.print(F(",\"holdMin\":"));        client.print(seg.holdMin);
+      client.print('}');
+    }
+    client.print(F("]}"));
+  }
+
+  client.print(']');
+}
+
+// ── Minimal JSON parser ────────────────────────────────────────────────────────
+// Parses only the custom-profiles subset (builtin profiles are never sent back).
+// Returns nullptr on success, or a short human-readable error string.
+
+static const char* skipWs(const char* p) {
+  while (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r') p++;
+  return p;
+}
+
+// Read a quoted string into buf (max len including null). Returns ptr after closing '"'.
+static const char* readStr(const char* p, char* buf, uint8_t maxLen) {
+  p = skipWs(p);
+  if (*p != '"') return nullptr;
+  p++;
+  uint8_t i = 0;
+  while (*p && *p != '"') {
+    if (i < maxLen) buf[i++] = *p;
+    p++;
+  }
+  if (*p != '"') return nullptr;
+  buf[i] = '\0';
+  return p + 1;
+}
+
+// Read an integer. Returns ptr after digits.
+static const char* readInt(const char* p, int32_t& out) {
+  p = skipWs(p);
+  bool neg = (*p == '-'); if (neg) p++;
+  if (*p < '0' || *p > '9') return nullptr;
+  out = 0;
+  while (*p >= '0' && *p <= '9') { out = out * 10 + (*p - '0'); p++; }
+  if (neg) out = -out;
+  return p;
+}
+
+// Skip a JSON value (string, number, object, array) — used to skip unknown keys.
+static const char* skipValue(const char* p);
+static const char* skipValue(const char* p) {
+  p = skipWs(p);
+  if (*p == '"') {
+    p++;
+    while (*p && *p != '"') { if (*p == '\\') p++; p++; }
+    return *p ? p + 1 : p;
+  }
+  if (*p == '{' || *p == '[') {
+    char open = *p, close = (*p == '{') ? '}' : ']';
+    p++; int depth = 1;
+    while (*p && depth > 0) {
+      if (*p == '"') { p++; while (*p && *p != '"') { if (*p == '\\') p++; p++; } if (*p) p++; continue; }
+      if (*p == open)  depth++;
+      if (*p == close) depth--;
+      p++;
+    }
+    return p;
+  }
+  while (*p && *p != ',' && *p != '}' && *p != ']') p++;
+  return p;
+}
+
+// Expect a specific character (after whitespace). Returns ptr after it, or nullptr.
+static const char* expect(const char* p, char c) {
+  p = skipWs(p);
+  return (*p == c) ? p + 1 : nullptr;
+}
+
+const char* parseAndSaveCustomProfiles(const char* json) {
+  const char* p = skipWs(json);
+  p = expect(p, '['); if (!p) return "Expected '['";
+
+  StoredProfile  tmp[MAX_CUSTOM_PROFILES];
+  uint8_t        cnt = 0;
+
+  p = skipWs(p);
+  while (*p && *p != ']') {
+    if (cnt >= MAX_CUSTOM_PROFILES) return "Too many profiles (max 5)";
+    p = expect(p, '{'); if (!p) return "Expected '{'";
+
+    StoredProfile& pr = tmp[cnt];
+    memset(&pr, 0, sizeof(pr));
+
+    p = skipWs(p);
+    while (*p && *p != '}') {
+      char key[20] = {};
+      p = readStr(p, key, 19); if (!p) return "Bad key";
+      p = skipWs(p);
+      p = expect(p, ':');      if (!p) return "Expected ':'";
+      p = skipWs(p);
+
+      if (strcmp(key, "id") == 0) {
+        p = readStr(p, pr.id, PROF_ID_LEN); if (!p) return "Bad id";
+      } else if (strcmp(key, "name") == 0) {
+        p = readStr(p, pr.name, PROF_NAME_LEN); if (!p) return "Bad name";
+      } else if (strcmp(key, "segments") == 0) {
+        p = expect(p, '['); if (!p) return "Expected segments array";
+        p = skipWs(p);
+        while (*p && *p != ']') {
+          if (pr.segCount >= MAX_SEGS_PER_PROFILE) return "Too many segments (max 8)";
+          p = expect(p, '{'); if (!p) return "Expected segment object";
+          StoredSegment& seg = pr.segs[pr.segCount];
+          memset(&seg, 0, sizeof(seg));
+          p = skipWs(p);
+          while (*p && *p != '}') {
+            char sk[20] = {};
+            p = readStr(p, sk, 19); if (!p) return "Bad segment key";
+            p = skipWs(p);
+            p = expect(p, ':');     if (!p) return "Expected ':'";
+            p = skipWs(p);
+            int32_t v = 0;
+            if (strcmp(sk, "name") == 0) {
+              p = readStr(p, seg.name, SEG_NAME_LEN); if (!p) return "Bad segment name";
+            } else if (strcmp(sk, "targetTemp") == 0) {
+              p = readInt(p, v); if (!p) return "Bad targetTemp";
+              if (v < 100 || v > 1400) return "targetTemp out of range (100-1400)";
+              seg.targetTemp = (uint16_t)v;
+            } else if (strcmp(sk, "ratePerHour") == 0) {
+              p = readInt(p, v); if (!p) return "Bad ratePerHour";
+              if (v < 0 || v > 9999) return "ratePerHour out of range (0-9999)";
+              seg.ratePerHour = (uint16_t)v;
+            } else if (strcmp(sk, "holdMin") == 0) {
+              p = readInt(p, v); if (!p) return "Bad holdMin";
+              if (v < 0 || v > 999) return "holdMin out of range (0-999)";
+              seg.holdMin = (uint16_t)v;
+            } else {
+              p = skipValue(p);
+            }
+            p = skipWs(p);
+            if (*p == ',') p++;
+            p = skipWs(p);
+          }
+          if (seg.name[0] == '\0') return "Segment missing name";
+          if (seg.targetTemp == 0) return "Segment missing targetTemp";
+          pr.segCount++;
+          p = expect(p, '}'); if (!p) return "Expected '}' after segment";
+          p = skipWs(p);
+          if (*p == ',') p++;
+          p = skipWs(p);
+        }
+        p = expect(p, ']'); if (!p) return "Expected ']' after segments";
+      } else {
+        // Skip unknown keys (e.g. "builtin" sent back from GUI)
+        p = skipValue(p);
+      }
+      p = skipWs(p);
+      if (*p == ',') p++;
+      p = skipWs(p);
+    }
+
+    if (pr.id[0] == '\0')   return "Profile missing id";
+    if (pr.name[0] == '\0') return "Profile missing name";
+    if (pr.segCount == 0)   return "Profile has no segments";
+
+    p = expect(p, '}'); if (!p) return "Expected '}' after profile";
+    cnt++;
+    p = skipWs(p);
+    if (*p == ',') p++;
+    p = skipWs(p);
+  }
+
+  // Commit
+  memcpy(_customStore, tmp, cnt * sizeof(StoredProfile));
+  _customCount = cnt;
+  rebuildWrappers();
+  saveCustomProfiles();
+  return nullptr; // success
+}

--- a/firmware/moen_kiln/moen_kiln.ino
+++ b/firmware/moen_kiln/moen_kiln.ino
@@ -8,6 +8,7 @@
 #include "Arduino_LED_Matrix.h"
 #include "config.h"
 #include "profiles.h"
+#include "custom_profiles.h"
 #include "web_ui.h"
 #include "led_display.h"
 #include "email.h"
@@ -143,6 +144,7 @@ void setup() {
   }
 
   loadPersistentLog();
+  loadCustomProfiles();
   setupWiFi();
 
   relayWinMs = millis();
@@ -833,6 +835,18 @@ void maybeReconnectWiFi() {
   Serial.println(F("WiFi: reconnect failed"));
 }
 
+// ── Profile helpers ───────────────────────────────────────────────────────────
+uint8_t getTotalProfileCount() {
+  return PROFILE_COUNT + customProfileCount;
+}
+
+const Profile* getProfileByIndex(uint8_t idx) {
+  if (idx < PROFILE_COUNT) return &PROFILES[idx];
+  uint8_t ci = idx - PROFILE_COUNT;
+  if (ci < customProfileCount) return &customProfiles[ci];
+  return nullptr;
+}
+
 // ── HTTP server ───────────────────────────────────────────────────────────────
 void handleHTTP() {
   if (WiFi.status() != WL_CONNECTED) return;
@@ -997,15 +1011,35 @@ void handleHTTP() {
     }
     client.print(']');
 
+  } else if (req.startsWith("GET /api/profiles")) {
+    httpOK(client, "application/json");
+    sendProfilesJSON(client);
+
+  } else if (req.startsWith("POST /api/profiles")) {
+    const char* err = parseAndSaveCustomProfiles(body.c_str());
+    httpOK(client, "application/json");
+    if (err) {
+      client.print(F("{\"ok\":false,\"error\":\""));
+      client.print(err);
+      client.print(F("\"}"));
+    } else {
+      client.print(F("{\"ok\":true}"));
+    }
+
   } else if (req.startsWith("POST /api/start")) {
     if (sensorMissing) {
       httpOK(client, "application/json"); client.print(F("{\"ok\":false,\"error\":\"no sensor\"}"));
     } else {
-      int idx = constrain(formParam(body, "profile").toInt(), 0, PROFILE_COUNT - 1);
+      int idx = constrain(formParam(body, "profile").toInt(), 0, (int)getTotalProfileCount() - 1);
+      const Profile* p = getProfileByIndex((uint8_t)idx);
       String mt = formParam(body, "maxtemp");
-      startProfile(&PROFILES[idx]);
-      if (mt.length() > 0) firingMaxTemp = (uint16_t)constrain(mt.toInt(), 100, 1400);
-      httpOK(client, "application/json"); client.print(F("{\"ok\":true}"));
+      if (p) {
+        startProfile(p);
+        if (mt.length() > 0) firingMaxTemp = (uint16_t)constrain(mt.toInt(), 100, 1400);
+        httpOK(client, "application/json"); client.print(F("{\"ok\":true}"));
+      } else {
+        httpOK(client, "application/json"); client.print(F("{\"ok\":false,\"error\":\"invalid profile\"}"));
+      }
     }
 
   } else if (req.startsWith("POST /api/relay")) {
@@ -1083,7 +1117,8 @@ void handleSerial() {
     if (sensorMissing) { Serial.println(F("ERROR: no sensor")); }
     else {
       int idx = cmd.substring(6).toInt();
-      if (idx >= 0 && (uint8_t)idx < PROFILE_COUNT) startProfile(&PROFILES[idx]);
+      const Profile* p = (idx >= 0) ? getProfileByIndex((uint8_t)idx) : nullptr;
+      if (p) startProfile(p);
       else Serial.println(F("Unknown profile"));
     }
 
@@ -1106,8 +1141,11 @@ void handleSerial() {
     if (WiFi.status() == WL_CONNECTED) Serial.println(WiFi.localIP());
     else Serial.println(F("Not connected"));
   } else if (cmd == "profiles") {
-    for (uint8_t i = 0; i < PROFILE_COUNT; i++) {
-      Serial.print(i); Serial.print(F(": ")); Serial.println(PROFILES[i].name);
+    for (uint8_t i = 0; i < getTotalProfileCount(); i++) {
+      const Profile* p = getProfileByIndex(i);
+      Serial.print(i); Serial.print(F(": ")); Serial.print(p->name);
+      if (i >= PROFILE_COUNT) Serial.print(F(" [custom]"));
+      Serial.println();
     }
   } else if (cmd == "display") {
     displayScreen = (displayScreen + 1) % 4;
@@ -1169,7 +1207,8 @@ void printStatus() {
 
 void printHelp() {
   Serial.println(F("Commands:"));
-  Serial.println(F("  start 0/1/2  – start profile (0=Glaze 1=Bisque 2=ConfigTest)"));
+  Serial.print(F("  start <n>    – start profile by index (type 'profiles' to list)"));
+  Serial.println();
   Serial.println(F("  stop / reset"));
   Serial.println(F("  relay on/off – manual relay (IDLE only)"));
   Serial.println(F("  display      – toggle LED mode"));

--- a/firmware/moen_kiln/web_ui.h
+++ b/firmware/moen_kiln/web_ui.h
@@ -49,6 +49,16 @@ button:disabled{opacity:0.35;cursor:not-allowed;transform:none!important;filter:
 .inp{width:100%;padding:8px;border-radius:6px;border:none;background:#333;color:#eee;font-size:.88em;margin-bottom:6px;display:block}
 .shead{color:#888;font-size:.82em;margin:10px 0 8px}
 details summary{cursor:pointer;color:#ff7700;font-size:.95em;touch-action:manipulation}
+.profrow{display:flex;align-items:center;gap:8px;padding:5px 0;border-bottom:1px solid #2a2a2a}
+.profrow:last-child{border-bottom:none}
+.profname{flex:1;font-size:.85em;color:#eee}
+.profbadge{font-size:.72em;color:#666;background:#2a2a2a;padding:2px 6px;border-radius:4px}
+.profbtn{flex:0 0 auto;padding:4px 10px;font-size:.78em;border:none;border-radius:5px;cursor:pointer;font-weight:600;touch-action:manipulation}
+.profbtn:active{filter:brightness(.75)}
+.profcopy{background:#333;color:#eee}
+.profdel{background:#5a1a1a;color:#ff6666}
+textarea.valid{border:1.5px solid #2e7d32}
+textarea.invalid{border:1.5px solid #b71c1c}
 #overlay{display:none;position:fixed;inset:0;background:rgba(0,0,0,.8);z-index:100;align-items:center;justify-content:center}
 #overlay.show{display:flex}
 #modal{background:#222;border-radius:14px;padding:28px 24px;max-width:300px;width:90%;text-align:center}
@@ -119,17 +129,33 @@ details summary{cursor:pointer;color:#ff7700;font-size:.95em;touch-action:manipu
 </div>
 <div class="card">
   <label>Firing profile</label>
-  <select id="pr">
-    <option value="0">Glaze</option>
-    <option value="1">Bisque</option>
-    <option value="2">Config Test</option>
-  </select>
+  <select id="pr"></select>
   <input class="inp" id="maxtemp" type="number" min="100" max="1400" placeholder="Max temp °C (default 1300)">
   <div class="btns">
     <button class="go" id="btn-go" onclick="go()">&#9654; Start</button>
     <button class="stop" id="btn-stop" onclick="stp()">&#9632; Stop</button>
     <button class="rst" id="btn-rst" onclick="rst()">&#8635; Reset</button>
   </div>
+</div>
+<div class="card">
+<details id="profdetails">
+<summary>Firing Profiles</summary>
+<div style="margin-top:10px">
+<p class="shead">Built-in profiles (read-only)</p>
+<div id="builtinList"></div>
+<p class="shead" style="margin-top:12px">Custom profiles</p>
+<div id="customList"></div>
+<div style="margin-top:10px">
+<p class="shead">Edit / add custom profile (JSON)</p>
+<textarea id="profJson" class="inp" rows="18" spellcheck="false" style="font-family:monospace;font-size:.73em;resize:vertical;white-space:pre"></textarea>
+<div id="profErr" style="color:#ff4444;font-size:.8em;margin-bottom:6px;min-height:1.2em"></div>
+<div class="btns">
+  <button class="rst" style="flex:0 0 auto;padding:10px 14px" onclick="loadProfiles()">&#8635; Reload</button>
+  <button class="go" id="btn-saveprof" onclick="saveProfiles()">&#8593; Save to device</button>
+</div>
+</div>
+</div>
+</details>
 </div>
 <div class="card">
 <details>
@@ -331,6 +357,164 @@ function saveSet(){
   fetch('/api/settings',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:b})
     .then(function(){alert('Saved!');});
 }
+// ── Profile editor ────────────────────────────────────────────────────────────
+var allProfiles=[];
+
+function loadProfiles(){
+  fetch('/api/profiles').then(function(r){return r.json();}).then(function(data){
+    allProfiles=data;
+    renderProfileSelect();
+    renderProfileLists();
+  }).catch(function(){});
+}
+
+function renderProfileSelect(){
+  var sel=document.getElementById('pr');
+  var prev=sel.value;
+  sel.innerHTML='';
+  allProfiles.forEach(function(p,i){
+    var opt=document.createElement('option');
+    opt.value=i;
+    opt.textContent=p.name+(p.builtin?' (built-in)':'');
+    sel.appendChild(opt);
+  });
+  // Restore selection if still valid
+  if(prev!==''&&prev<allProfiles.length) sel.value=prev;
+}
+
+function renderProfileLists(){
+  var builtinEl=document.getElementById('builtinList');
+  var customEl=document.getElementById('customList');
+  builtinEl.innerHTML=''; customEl.innerHTML='';
+  allProfiles.forEach(function(p,i){
+    var row=document.createElement('div');
+    row.className='profrow';
+    row.innerHTML='<span class="profname">'+escH(p.name)+'</span>'
+      +'<span class="profbadge">'+p.segments.length+' seg</span>';
+    if(p.builtin){
+      var btn=document.createElement('button');
+      btn.className='profbtn profcopy'; btn.textContent='Copy';
+      (function(prof){btn.onclick=function(){copyProfile(prof);};})(p);
+      row.appendChild(btn);
+      builtinEl.appendChild(row);
+    } else {
+      var editBtn=document.createElement('button');
+      editBtn.className='profbtn profcopy'; editBtn.textContent='Edit';
+      (function(prof){editBtn.onclick=function(){editProfile(prof);};})(p);
+      var delBtn=document.createElement('button');
+      delBtn.className='profbtn profdel'; delBtn.textContent='Del';
+      (function(idx){delBtn.onclick=function(){deleteProfile(idx);};})(i);
+      row.appendChild(editBtn); row.appendChild(delBtn);
+      customEl.appendChild(row);
+    }
+  });
+  if(customEl.children.length===0){
+    customEl.innerHTML='<div style="color:#555;font-size:.82em;padding:6px 0">No custom profiles yet — copy a built-in to get started.</div>';
+  }
+}
+
+function escH(s){return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');}
+
+function copyProfile(p){
+  var copy=JSON.parse(JSON.stringify(p));
+  delete copy.builtin;
+  copy.id=copy.id+'-copy';
+  copy.name=copy.name+' (copy)';
+  setEditorJSON(copy);
+  document.getElementById('profdetails').open=true;
+  document.getElementById('profJson').scrollIntoView({behavior:'smooth',block:'nearest'});
+}
+
+function editProfile(p){
+  var copy=JSON.parse(JSON.stringify(p));
+  delete copy.builtin;
+  setEditorJSON(copy);
+  document.getElementById('profdetails').open=true;
+  document.getElementById('profJson').scrollIntoView({behavior:'smooth',block:'nearest'});
+}
+
+function deleteProfile(globalIdx){
+  var p=allProfiles[globalIdx];
+  if(!p||p.builtin) return;
+  if(!confirm('Delete profile "'+p.name+'"?')) return;
+  var customs=allProfiles.filter(function(x){return !x.builtin;});
+  customs=customs.filter(function(x){return x.id!==p.id;});
+  postCustoms(customs);
+}
+
+function setEditorJSON(obj){
+  var ta=document.getElementById('profJson');
+  ta.value=JSON.stringify(obj,null,2);
+  validateEditor();
+}
+
+function validateEditor(){
+  var ta=document.getElementById('profJson');
+  var errEl=document.getElementById('profErr');
+  var raw=ta.value.trim();
+  if(!raw){ta.className='inp';errEl.textContent='';return null;}
+  var parsed;
+  try{ parsed=JSON.parse(raw); }
+  catch(e){ ta.className='inp invalid'; errEl.textContent='✘ '+e.message; return null; }
+  // Semantic validation of a single profile object
+  var profiles=Array.isArray(parsed)?parsed:[parsed];
+  for(var pi=0;pi<profiles.length;pi++){
+    var p=profiles[pi];
+    if(typeof p.id!=='string'||!p.id.trim()){ setErr(ta,errEl,'Profile missing "id"'); return null; }
+    if(typeof p.name!=='string'||!p.name.trim()){ setErr(ta,errEl,'Profile missing "name"'); return null; }
+    if(p.name.length>15){ setErr(ta,errEl,'name too long (max 15 chars)'); return null; }
+    if(!Array.isArray(p.segments)||p.segments.length===0){ setErr(ta,errEl,'Profile needs at least 1 segment'); return null; }
+    if(p.segments.length>8){ setErr(ta,errEl,'Too many segments (max 8)'); return null; }
+    for(var si=0;si<p.segments.length;si++){
+      var s=p.segments[si];
+      if(typeof s.name!=='string'||!s.name.trim()){ setErr(ta,errEl,'Segment '+(si+1)+' missing name'); return null; }
+      if(s.name.length>11){ setErr(ta,errEl,'Segment name too long (max 11 chars)'); return null; }
+      if(typeof s.targetTemp!=='number'||s.targetTemp<100||s.targetTemp>1400){ setErr(ta,errEl,'Segment '+(si+1)+': targetTemp must be 100–1400'); return null; }
+      if(typeof s.ratePerHour!=='number'||s.ratePerHour<0||s.ratePerHour>9999){ setErr(ta,errEl,'Segment '+(si+1)+': ratePerHour must be 0–9999'); return null; }
+      if(typeof s.holdMin!=='number'||s.holdMin<0||s.holdMin>999){ setErr(ta,errEl,'Segment '+(si+1)+': holdMin must be 0–999'); return null; }
+    }
+  }
+  ta.className='inp valid';
+  errEl.textContent='✓ Valid — '+profiles.length+' profile(s), '+profiles.reduce(function(a,p){return a+p.segments.length;},0)+' segments total';
+  errEl.style.color='#44bb44';
+  return profiles;
+}
+
+function setErr(ta,errEl,msg){ ta.className='inp invalid'; errEl.style.color='#ff4444'; errEl.textContent='✘ '+msg; }
+
+function saveProfiles(){
+  var profiles=validateEditor();
+  if(!profiles) return;
+  // Merge: keep existing customs that are not being replaced, then add/update edited ones
+  var existing=allProfiles.filter(function(p){return !p.builtin;});
+  var editedIds=profiles.map(function(p){return p.id;});
+  var kept=existing.filter(function(p){return editedIds.indexOf(p.id)===-1;});
+  var merged=kept.concat(profiles);
+  if(merged.length>5){ alert('Too many custom profiles (max 5 total)'); return; }
+  postCustoms(merged);
+}
+
+function postCustoms(customs){
+  var clean=customs.map(function(p){
+    return {id:p.id,name:p.name,segments:p.segments.map(function(s){
+      return {name:s.name,targetTemp:s.targetTemp,ratePerHour:s.ratePerHour,holdMin:s.holdMin};
+    })};
+  });
+  fetch('/api/profiles',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(clean)})
+    .then(function(r){return r.json();})
+    .then(function(d){
+      if(d.ok){ loadProfiles(); }
+      else{ alert('Error: '+(d.error||'unknown')); }
+    }).catch(function(){});
+}
+
+document.getElementById('profJson').addEventListener('input',function(){
+  var r=validateEditor();
+  document.getElementById('profErr').style.color=(r?'#44bb44':'#ff4444');
+});
+
+loadProfiles();
+
 poll();
 refreshLog();
 setInterval(refreshLog, 300000);


### PR DESCRIPTION
## Summary
Adds a JSON-based firing profile editor to the web GUI. Built-in profiles are read-only; users can copy them to create editable custom profiles.

## Changes

### `config.h`
- New EEPROM block at addresses 5464–6351 for custom profiles
- Constants: `MAX_CUSTOM_PROFILES` (5), `MAX_SEGS_PER_PROFILE` (8), name length limits

### `custom_profiles.h` (new file)
- `StoredProfile` / `StoredSegment` structs (char arrays, EEPROM-serialisable)
- `loadCustomProfiles()` / `saveCustomProfiles()` (EEPROM persistence)
- `sendProfilesJSON()` — template, serialises both built-in and custom profiles
- `parseAndSaveCustomProfiles()` — minimal inline JSON parser, no ArduinoJson dependency

### `moen_kiln.ino`
- Calls `loadCustomProfiles()` at boot
- `getTotalProfileCount()` + `getProfileByIndex()` helpers unify built-in and custom access
- `GET /api/profiles` — returns full JSON array (builtin + custom, `"builtin": true/false`)
- `POST /api/profiles` — receives custom-only array, validates, saves to EEPROM
- `POST /api/start` supports indices ≥ PROFILE_COUNT for custom profiles
- Serial `start` and `profiles` commands updated accordingly

### `web_ui.h`
- Profile `<select>` now dynamically populated from `/api/profiles`
- New **Firing Profiles** `<details>` section:
  - Built-in profiles shown read-only with a **Copy** button
  - Custom profiles listed with **Edit** and **Delete** buttons
  - JSON textarea editor (single profile or array)
  - Live validation: syntax (JSON.parse) + semantic (field types, ranges, lengths)
  - **Reload** and **Save to device** buttons

## Behaviour
- Built-in profiles (Glaze, Bisque, Config Test) cannot be edited or deleted
- Copy a built-in → textarea opens with a duplicate → edit → Save
- Custom profiles survive reflash (stored in EEPROM)
- Max 5 custom profiles, max 8 segments each

## Known limitation
Pending email reports (saved to EEPROM when WiFi is unavailable) store the profile as a built-in index. If a custom profile was used, the report will fall back to index 0 (Glaze). This is pre-existing behaviour not addressed in this PR.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)