### PR TITLE
Remove max temp override field and redesign main card for context-aware display

### DIFF
--- a/firmware/moen_kiln/moen_kiln.ino
+++ b/firmware/moen_kiln/moen_kiln.ino
@@ -98,7 +98,6 @@ bool    sensorMissing    = false; // MAX31855 ikke tilkoblet eller feiler
 uint8_t sensorErrCount   = 0;    // konsekutive NaN-avlesninger – alarm ved 3
 unsigned long testTimeoutMs  = 0; // non-zero under Config Test: fires at firingStartMs + 4 h
 unsigned long lastWifiRetryMs = 0; // last time we attempted a reconnect
-uint16_t      firingMaxTemp  = 0; // per-firing max temp override; 0 = use MAX_TEMP_C
 
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -416,8 +415,7 @@ void updateStatusLED() {
 
 // ── Alarmer ───────────────────────────────────────────────────────────────────
 void checkAlarms() {
-  float maxT = (firingMaxTemp > 0) ? (float)firingMaxTemp : MAX_TEMP_C;
-  if (currentTemp > maxT) triggerAlarm(F("Max temperature exceeded"), EV_ERR_MAXTEMP);
+  if (currentTemp > MAX_TEMP_C) triggerAlarm(F("Max temperature exceeded"), EV_ERR_MAXTEMP);
 }
 
 void triggerAlarm(const __FlashStringHelper* alarmMsg, uint8_t evType) {
@@ -896,7 +894,6 @@ void handleHTTP() {
     if (firingStartMs > 0) { client.print(F(",\"elapsed\":")); client.print((millis() - firingStartMs) / 1000UL); }
     client.print(F(",\"firingId\":")); client.print(firingId);
     client.print(F(",\"sensorMissing\":")); client.print(sensorMissing ? "true" : "false");
-    if (firingMaxTemp > 0) { client.print(F(",\"maxTemp\":")); client.print(firingMaxTemp); }
     if (profile) {
       client.print(F(",\"profile\":\"")); client.print(profile->name); client.print('"');
       client.print(F(",\"segIdx\":")); client.print(segIdx);
@@ -1032,10 +1029,8 @@ void handleHTTP() {
     } else {
       int idx = constrain(formParam(body, "profile").toInt(), 0, (int)getTotalProfileCount() - 1);
       const Profile* p = getProfileByIndex((uint8_t)idx);
-      String mt = formParam(body, "maxtemp");
       if (p) {
         startProfile(p);
-        if (mt.length() > 0) firingMaxTemp = (uint16_t)constrain(mt.toInt(), 100, 1400);
         httpOK(client, "application/json"); client.print(F("{\"ok\":true}"));
       } else {
         httpOK(client, "application/json"); client.print(F("{\"ok\":false,\"error\":\"invalid profile\"}"));

--- a/firmware/moen_kiln/web_ui.h
+++ b/firmware/moen_kiln/web_ui.h
@@ -69,18 +69,20 @@ textarea.invalid{border:1.5px solid #b71c1c}
     <div class="trend" id="trend">→</div>
   </div>
   <div class="phase" id="ph">---</div>
-  <div id="segtl" class="segtl"></div>
-  <div id="segdetail" class="segdetail"></div>
-  <div class="pbar" style="margin-top:8px"><div class="pfill" id="pg"></div></div>
-  <div class="pills">
-    <div class="pill">Rate: <b id="rate">--</b>°C/h</div>
-    <div class="pill">Duty cycle: <b id="pid">--</b>%</div>
-    <div class="pill" id="pill-stgt" style="display:none">Segment target: <b id="stgt">--</b>°C</div>
-    <div class="pill" id="pill-seta" style="display:none">Time to target: <b id="seta">--</b></div>
-    <div class="pill" id="rem"></div>
-    <div class="pill" id="tot"></div>
-    <div class="pill" id="et"></div>
-    <div class="pill" id="pill-nosensor" style="display:none;background:#5a1a1a;color:#ff6666">&#9888; No sensor</div>
+  <div class="pill" id="pill-nosensor" style="display:none;background:#5a1a1a;color:#ff6666;margin-top:8px">&#9888; No sensor</div>
+  <div id="firing-details" style="display:none">
+    <div id="segtl" class="segtl"></div>
+    <div id="segdetail" class="segdetail"></div>
+    <div class="pbar" style="margin-top:8px"><div class="pfill" id="pg"></div></div>
+    <div class="pills">
+      <div class="pill">Rate: <b id="rate">--</b>°C/h</div>
+      <div class="pill">Duty cycle: <b id="pid">--</b>%</div>
+      <div class="pill" id="pill-stgt" style="display:none">Segment target: <b id="stgt">--</b>°C</div>
+      <div class="pill" id="pill-seta" style="display:none">Time to target: <b id="seta">--</b></div>
+      <div class="pill" id="rem"></div>
+      <div class="pill" id="tot"></div>
+      <div class="pill" id="et"></div>
+    </div>
   </div>
   <div class="donebox" id="donebox">🎉</div>
 </div>
@@ -116,7 +118,6 @@ textarea.invalid{border:1.5px solid #b71c1c}
 <div class="card">
   <label>🎨 Firing profile</label>
   <select id="pr"></select>
-  <input class="inp" id="maxtemp" type="number" min="100" max="1400" placeholder="Max temp °C (default 1300)">
   <div class="btns">
     <button class="go" id="btn-go" onclick="go()">🔥 Start</button>
     <button class="stop" id="btn-stop" onclick="stp()">🛑 Stop</button>
@@ -230,6 +231,7 @@ fetch('/api/status').then(function(r){return r.json();}).then(function(d){
   document.getElementById('donebox').style.display=(d.state==='DONE')?'block':'none';
 
   var active=(d.state==='RAMP'||d.state==='HOLD'||d.state==='COOL');
+  document.getElementById('firing-details').style.display=active?'':'none';
   document.getElementById('btn-go').disabled=active||(d.sensorMissing===true);
   document.getElementById('pill-nosensor').style.display=d.sensorMissing?'':'none';
   document.getElementById('btn-stop').disabled=!active;
@@ -326,7 +328,7 @@ function refreshLog(){
     el.innerHTML=html;
   }).catch(function(){});
 }
-function go(){var mt=document.getElementById('maxtemp').value;var body='profile='+document.getElementById('pr').value+(mt?'&maxtemp='+parseInt(mt):'');fetch('/api/start',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:body}).then(function(r){return r.json();}).then(function(d){if(!d.ok)alert('Cannot start: '+(d.error||'unknown error'));}).catch(function(){});}
+function go(){var body='profile='+document.getElementById('pr').value;fetch('/api/start',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:body}).then(function(r){return r.json();}).then(function(d){if(!d.ok)alert('Cannot start: '+(d.error||'unknown error'));}).catch(function(){});}
 function stp(){if(!confirm('Stop the firing?'))return;fetch('/api/stop',{method:'POST'});}
 function rst(){fetch('/api/reset',{method:'POST'});}
 fetch('/api/settings').then(function(r){return r.json();}).then(function(d){


### PR DESCRIPTION
Closes #52, closes #53

## Changes

### #52 — Remove max temp override field
- Removed `<input id="maxtemp">` from Firing Profile card
- Simplified `go()` — POST body now contains only the `profile` param
- Removed `firingMaxTemp` variable declaration and form-param parsing in `moen_kiln.ino`
- Removed `maxTemp` field from `/api/status` response
- The hard safety ceiling (`MAX_TEMP_C = 1300°C`) is retained as a compile-time constant

### #53 — Context-aware main card
- Wrapped `segtl`, `segdetail`, `pbar`, and stat pills in `<div id="firing-details" style="display:none">`
- Moved `#pill-nosensor` outside the wrapper — always visible regardless of state
- `poll()` now toggles `#firing-details` visibility based on state:
  - **RAMP / HOLD / COOL** → full dashboard visible
  - **IDLE / DONE / STOP / ERR** → only temperature + phase text shown
- DONE state retains the 🎉 donebox

## Before / After

**IDLE before:** temperature + empty pills + flat progress bar + dashed values — looked broken  
**IDLE after:** temperature + phase text only — clean and minimal

🤖 Generated with [Claude Code](https://claude.com/claude-code)