### PR TITLE
Skip-ahead past already-passed segments on hot start (#71)

### DIFF
--- a/firmware/moen_kiln/moen_kiln.ino
+++ b/firmware/moen_kiln/moen_kiln.ino
@@ -1232,6 +1232,21 @@ void startProfile(const Profile* p) {
   Serial.print(F("Starting: ")); Serial.println(p->name);
   readTemp();
   if (sensorMissing) { kilnState = IDLE; return; }
+
+  // Skip-ahead (#71): if the kiln is already hot, skip leading rising segments
+  // whose target the kiln has already climbed past, so the firing resumes at the
+  // segment matching the current temperature instead of treating early segments
+  // as cooling phases. Never skips past the last segment, and only touches the
+  // leading run at start — later cooling segments are left untouched.
+  while (segIdx < profile->segCount - 1 &&
+         profile->segments[segIdx].targetTemp <= currentTemp) {
+    segIdx++;
+  }
+  if (segIdx > 0) {
+    Serial.print(F("Skip-ahead: starting at segment ")); Serial.print(segIdx + 1);
+    Serial.print(F(" (kiln at ")); Serial.print(currentTemp, 0); Serial.println(F("C)"));
+  }
+
   firingId++;
   cloudLogNewFiring();
   EEPROM.update(EEPROM_PLOG_FLAG, 0);


### PR DESCRIPTION
Closes #71.

## What

When a firing is started while the kiln is already hot, `startProfile()` now skips the leading rising segments whose target the kiln has already climbed past, so the firing resumes at the segment matching the current temperature — instead of treating those early segments as cooling phases (relay off, waiting for natural cool-down).

## Behaviour

```cpp
while (segIdx < profile->segCount - 1 &&
       profile->segments[segIdx].targetTemp <= currentTemp) {
  segIdx++;
}
```

- Skips the contiguous leading run of segments whose `targetTemp <= currentTemp` (including already-passed holds — standard skip-ahead, matches Bartlett/Orton controllers).
- Stops at the first segment with `targetTemp > currentTemp`, then ramps normally from `currentTemp`.
- **Never skips past the last segment** (`segCount - 1` bound), so a program entirely below the current temperature lands safely on the last segment.
- Only affects the **leading run at start** — legitimate cooling segments later in the profile are untouched.
- Logs the resume segment to Serial for traceability.

## Verification

- Compiles for `arduino:renesas_uno:unor4wifi` (57% flash, 62% RAM).
- No Azure / endpoint changes; firmware logic only. No GDPR surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)