### PR TITLE
CloudLog: CSV export, explicit firing-end status, and chart zoom

### DIFF
--- a/cloud/function/sql/002_firing_meta.sql
+++ b/cloud/function/sql/002_firing_meta.sql
@@ -1,0 +1,17 @@
+-- Migration 002: explicit firing-end metadata.
+-- Run once against the miln database as the table owner, then GRANT to miln_app.
+-- Additive and online — safe to run on a live database (no downtime).
+
+-- One row per firing, written by POST /api/firing-end when MILN ends a firing.
+-- Kept separate from the append-only firing_log measurement series so that
+-- end metadata never pollutes aggregates (MAX(temp_c), COUNT(*), ...).
+CREATE TABLE IF NOT EXISTS firing_meta (
+  firing_id   INTEGER     PRIMARY KEY,
+  ended_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  end_reason  TEXT        NOT NULL DEFAULT 'completed'
+    CHECK (end_reason IN ('completed', 'stopped', 'estop', 'disconnected')),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- firing_id is client-supplied (not SERIAL/IDENTITY), so no sequence grant needed.
+GRANT SELECT, INSERT, UPDATE, DELETE ON firing_meta TO miln_app;

--- a/cloud/function/src/firing-end.js
+++ b/cloud/function/src/firing-end.js
@@ -1,0 +1,53 @@
+const { app } = require('@azure/functions');
+const { getPool } = require('./db');
+
+const VALID_REASONS = ['completed', 'stopped', 'estop', 'disconnected'];
+
+// Called once by MILN when a firing ends (completed / stopped / e-stopped).
+// Idempotent UPSERT so WiFi retries can't create duplicates or races.
+app.http('firing-end', {
+  methods: ['POST'],
+  authLevel: 'anonymous',
+  route: 'firing-end',
+  handler: async (req, ctx) => {
+    if (req.headers.get('x-kiln-key') !== process.env.KILN_API_KEY) {
+      return { status: 401, body: 'Unauthorized' };
+    }
+
+    if (!req.headers.get('content-type')?.includes('application/json')) {
+      return { status: 400, body: 'Content-Type must be application/json' };
+    }
+
+    let body;
+    try { body = await req.json(); } catch { return { status: 400, body: 'Invalid JSON' }; }
+
+    const { firing_id, reason } = body;
+
+    // Strict: only a real positive integer, never a coercible value (true → 1).
+    if (typeof firing_id !== 'number' || !Number.isInteger(firing_id) || firing_id < 1) {
+      return { status: 400, body: 'Missing or invalid firing_id' };
+    }
+
+    // Reject unknown reasons rather than silently masking e.g. an estop as completed.
+    if (reason !== undefined && !VALID_REASONS.includes(reason)) {
+      return { status: 400, body: 'Invalid reason' };
+    }
+    const endReason = reason || 'completed';
+
+    try {
+      await getPool().query(
+        `INSERT INTO firing_meta (firing_id, ended_at, end_reason, updated_at)
+         VALUES ($1, now(), $2, now())
+         ON CONFLICT (firing_id) DO UPDATE
+           SET ended_at   = EXCLUDED.ended_at,
+               end_reason = EXCLUDED.end_reason,
+               updated_at = now()`,
+        [firing_id, endReason]
+      );
+      return { status: 200, body: 'ok' };
+    } catch (err) {
+      ctx.error('firing-end upsert error:', err.message);
+      return { status: 500, body: 'Database error' };
+    }
+  },
+});

--- a/cloud/function/src/firings.js
+++ b/cloud/function/src/firings.js
@@ -21,15 +21,18 @@ app.http('firings', {
     try {
       const r = await getPool().query(`
         SELECT
-          firing_id,
-          MIN(ts)     AS started_at,
-          MAX(ts)     AS last_seen_at,
-          COUNT(*)    AS point_count,
-          MAX(temp_c) AS max_temp_c,
-          BOOL_OR(is_err) AS had_error
-        FROM firing_log
-        GROUP BY firing_id
-        ORDER BY firing_id DESC
+          fl.firing_id,
+          MIN(fl.ts)     AS started_at,
+          MAX(fl.ts)     AS last_seen_at,
+          COUNT(*)       AS point_count,
+          MAX(fl.temp_c) AS max_temp_c,
+          BOOL_OR(fl.is_err) AS had_error,
+          fm.ended_at,
+          fm.end_reason
+        FROM firing_log fl
+        LEFT JOIN firing_meta fm ON fm.firing_id = fl.firing_id
+        GROUP BY fl.firing_id, fm.ended_at, fm.end_reason
+        ORDER BY fl.firing_id DESC
       `);
       return { status: 200, jsonBody: r.rows };
     } catch (err) {

--- a/cloud/function/src/index.js
+++ b/cloud/function/src/index.js
@@ -3,5 +3,6 @@ require('./auth-request');
 require('./auth-verify');
 require('./firings');
 require('./firing');
+require('./firing-end');
 require('./ingest');
 require('./tc-log');

--- a/cloud/web/dashboard.html
+++ b/cloud/web/dashboard.html
@@ -5,6 +5,8 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>MilnCloudLog</title>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/hammerjs@2.0.8/hammer.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2/dist/chartjs-plugin-zoom.min.js"></script>
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
 body{background:#111;color:#eee;font-family:system-ui,sans-serif;padding:0;max-width:720px;margin:0 auto}
@@ -31,6 +33,15 @@ table{width:100%;border-collapse:collapse;font-size:.78em;min-width:340px}
 th{text-align:left;padding:5px 6px;color:#666;font-weight:normal;border-bottom:1px solid #333;position:sticky;top:0;background:#222}
 td{padding:5px 6px;border-bottom:1px solid #1e1e1e}
 .live-badge{background:#1a3010;color:#88cc44;border-radius:5px;padding:2px 9px;font-size:.78em;margin-left:8px}
+.st-badge{display:inline-block;border-radius:5px;padding:2px 9px;font-size:.78em;margin-left:8px;white-space:nowrap}
+.st-done{background:#13261a;color:#5fbf7a}
+.st-stopped{background:#2a2317;color:#caa45a}
+.st-estop{background:#2a1010;color:#ff6666}
+.st-disc{background:#241c10;color:#cc9944}
+.btn-csv{background:none;border:1px solid #ff7700;color:#ff7700;border-radius:6px;padding:5px 12px;cursor:pointer;font-size:.82em;transition:all .15s}
+.btn-csv:hover{background:#ff7700;color:#fff}
+.btn-zoom{background:none;border:1px solid #333;color:#888;border-radius:6px;padding:3px 10px;cursor:pointer;font-size:.78em}
+.btn-zoom:hover{border-color:#555;color:#ccc}
 .pill{display:inline-block;background:#2a2a2a;border-radius:5px;padding:3px 10px;font-size:.82em;margin:2px}
 .pill b{color:#ff9933}
 #msg{text-align:center;color:#555;padding:24px}
@@ -91,7 +102,10 @@ td{padding:5px 6px;border-bottom:1px solid #1e1e1e}
       </div>
       <div id="tc-stats" style="color:#555;font-size:.84em">Laster…</div>
     </div>
-    <div class="card" style="padding:8px"><canvas id="tc-cv" height="200"></canvas></div>
+    <div class="card" style="padding:8px">
+      <div style="text-align:right;margin-bottom:4px"><button class="btn-zoom" onclick="tcChart && tcChart.resetZoom()">Tilbakestill zoom</button></div>
+      <canvas id="tc-cv" height="200"></canvas>
+    </div>
     <div class="card" style="padding:10px 8px">
       <div class="tbl-wrap">
         <table>
@@ -115,6 +129,34 @@ let chart        = null;
 let tcChart      = null;
 let tcBatches    = [];
 let detailCharts = new Map();
+let firingsById  = {};          // firing_id -> row (carries ended_at / end_reason)
+let curFiring    = { id: null, data: [] };
+
+const LIVE_WINDOW_MS = 3 * 60 * 1000;
+const DISC_WINDOW_MS = 6 * 60 * 60 * 1000;   // beyond this, a firing with no end signal is just history
+
+// Firing status from a row carrying ended_at/end_reason and a last-activity time:
+//   ended (explicit signal) · live (fresh points) · disconnected (recently
+//   stale, no end signal) · old (long stale → treated as history, no badge).
+function firingStatus(endedAt, endReason, lastActivity) {
+  if (endedAt) return { kind: 'ended', reason: endReason || 'completed' };
+  const age = lastActivity ? Date.now() - new Date(lastActivity) : Infinity;
+  if (age < LIVE_WINDOW_MS) return { kind: 'live' };
+  if (age < DISC_WINDOW_MS) return { kind: 'disconnected' };
+  return { kind: 'old' };
+}
+
+function statusBadge(st) {
+  switch (st.kind) {
+    case 'live': return '<span class="live-badge">● LIVE</span>';
+    case 'disconnected': return '<span class="st-badge st-disc">⚠ Frakoblet</span>';
+    case 'ended':
+      if (st.reason === 'estop')   return '<span class="st-badge st-estop">⚠ Nødstopp</span>';
+      if (st.reason === 'stopped') return '<span class="st-badge st-stopped">■ Stoppet</span>';
+      return '<span class="st-badge st-done">✓ Fullført</span>';
+  }
+  return '';   // 'old' → no badge
+}
 
 // ── Auth ──────────────────────────────────────────────────────────────────────
 async function init() {
@@ -178,13 +220,16 @@ async function loadFirings() {
   if (!data.length) { msg.textContent = 'Ingen brenninger registrert ennå.'; return; }
   msg.style.display = 'none';
 
+  firingsById = {};
+  data.forEach(f => { firingsById[f.firing_id] = f; });
+
   list.innerHTML = data.map(f => {
     const date = new Date(f.started_at).toLocaleDateString('no-NO', { day:'2-digit', month:'2-digit', year:'numeric' });
     const time = new Date(f.started_at).toLocaleTimeString('no-NO', { hour:'2-digit', minute:'2-digit' });
-    const live = Date.now() - new Date(f.last_seen_at) < 3 * 60 * 1000;
+    const st   = firingStatus(f.ended_at, f.end_reason, f.last_seen_at);
     return `<div class="firing-row" onclick="loadFiring(${f.firing_id})">
       <span class="fid">#${f.firing_id}</span>
-      <span class="fmeta">${date} ${time}&ensp;·&ensp;${f.point_count} pt${live ? '<span class="live-badge">● LIVE</span>' : ''}</span>
+      <span class="fmeta">${date} ${time}&ensp;·&ensp;${f.point_count} pt${statusBadge(st)}</span>
       <span class="fmax">${f.max_temp_c ? Math.round(f.max_temp_c) + '°C' : '--'}${f.had_error ? '<span class="ferr">⚠</span>' : ''}</span>
     </div>`;
   }).join('');
@@ -217,8 +262,12 @@ async function loadFiring(id) {
 
 function renderFiring(id, data) {
   if (chart) { chart.destroy(); chart = null; }
+  curFiring = { id, data };
   const view   = document.getElementById('view-detail');
-  const isLive = data.length && (Date.now() - new Date(data[data.length - 1].ts) < 3 * 60 * 1000);
+  const row     = firingsById[id];
+  const lastTs  = data.length ? data[data.length - 1].ts : (row && row.last_seen_at);
+  const st      = firingStatus(row && row.ended_at, row && row.end_reason, lastTs);
+  const badge   = statusBadge(st);
   const maxTemp  = data.reduce((m, p) => Math.max(m, p.temp_c || 0), 0);
   const lastSec  = data.length ? (data[data.length - 1].sec_elapsed || 0) : 0;
   const h = Math.floor(lastSec / 3600), m = Math.floor((lastSec % 3600) / 60);
@@ -228,13 +277,17 @@ function renderFiring(id, data) {
     <div class="card">
       <div style="display:flex;align-items:center;flex-wrap:wrap;gap:6px;margin-bottom:10px">
         <span style="color:#ff7700;font-weight:700;font-size:1.1em">Brenning #${id}</span>
-        ${isLive ? '<span class="live-badge">● LIVE</span>' : ''}
+        ${badge}
+        <button class="btn-csv" style="margin-left:auto" onclick="downloadFiringCsv()"${data.length ? '' : ' disabled'}>⬇ Last ned CSV</button>
       </div>
       <span class="pill">Maks: <b>${Math.round(maxTemp)}°C</b></span>
       <span class="pill">Varighet: <b>${h}t ${m}m</b></span>
       <span class="pill">Datapunkter: <b>${data.length}</b></span>
     </div>
-    <div class="card" style="padding:8px"><canvas id="cv" height="200"></canvas></div>
+    <div class="card" style="padding:8px">
+      <div style="text-align:right;margin-bottom:4px"><button class="btn-zoom" onclick="chart && chart.resetZoom()">Tilbakestill zoom</button></div>
+      <canvas id="cv" height="200"></canvas>
+    </div>
     <div class="card" style="padding:10px 8px">
       <div class="tbl-wrap">
         <table>
@@ -268,7 +321,13 @@ function renderFiring(id, data) {
         x: { ticks: { color: '#555', maxTicksLimit: 10 }, grid: { color: '#2a2a2a' } },
         y: { ticks: { color: '#555' }, grid: { color: '#2a2a2a' } },
       },
-      plugins: { legend: { labels: { color: '#aaa', boxWidth: 14 } } },
+      plugins: {
+        legend: { labels: { color: '#aaa', boxWidth: 14 } },
+        zoom: {
+          pan:  { enabled: true, mode: 'x' },
+          zoom: { wheel: { enabled: true }, pinch: { enabled: true }, mode: 'x' },
+        },
+      },
     },
   });
 
@@ -294,6 +353,30 @@ function backToList() {
   if (chart)     { chart.destroy(); chart = null; }
   document.getElementById('view-detail').style.display = 'none';
   document.getElementById('view-list').style.display   = '';
+}
+
+// ── CSV export ────────────────────────────────────────────────────────────────
+function downloadFiringCsv() {
+  const { id, data } = curFiring;
+  if (!data || !data.length) return;
+
+  const cols = ['ts', 'sec_elapsed', 'temp_c', 'setpoint_c', 'relay', 'duty_pct', 'segment', 'is_err'];
+  const esc  = v => {
+    if (v == null) return '';
+    const s = String(v);
+    return /[",\n]/.test(s) ? '"' + s.replace(/"/g, '""') + '"' : s;
+  };
+  const csv = cols.join(',') + '\n' +
+    data.map(p => cols.map(c => esc(p[c])).join(',')).join('\n') + '\n';
+
+  const d     = new Date(data[0].ts);
+  const stamp = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  const blob  = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+  const a     = document.createElement('a');
+  a.href      = URL.createObjectURL(blob);
+  a.download  = `brenning-${id}-${stamp}.csv`;
+  document.body.appendChild(a); a.click(); a.remove();
+  setTimeout(() => URL.revokeObjectURL(a.href), 1000);
 }
 
 // ── TC log ────────────────────────────────────────────────────────────────────
@@ -376,7 +459,13 @@ async function loadTcLog(hours, btn) {
         x: { ticks: { color: '#555', maxTicksLimit: 8 }, grid: { color: '#2a2a2a' } },
         y: { ticks: { color: '#555' }, grid: { color: '#2a2a2a' } },
       },
-      plugins: { legend: { display: false } },
+      plugins: {
+        legend: { display: false },
+        zoom: {
+          pan:  { enabled: true, mode: 'x' },
+          zoom: { wheel: { enabled: true }, pinch: { enabled: true }, mode: 'x' },
+        },
+      },
     },
   });
 

--- a/firmware/moen_kiln/cloud_log.h
+++ b/firmware/moen_kiln/cloud_log.h
@@ -14,9 +14,21 @@ extern const Profile* profile;
 #define EEPROM_CLOUD_ENABLED    6351    // 1 byte : 0x01 = enabled
 #define EEPROM_CLOUD_FIRING_ID  6352    // 2 bytes: persistent uint16_t counter
 
+// Endpoint that receives the one-shot "firing ended" signal. Override in
+// config_secrets.h if your deployment differs.
+#ifndef CLOUD_LOG_END_PATH
+#define CLOUD_LOG_END_PATH      "/api/firing-end"
+#endif
+
+#define CLOUD_LOG_END_RETRY_MS  30000UL
+
 static bool     _clEnabled  = false;
 static uint16_t _clFiringId = 0;
 static unsigned long _clLastMs = 0;
+static bool     _clEnded     = false;        // firing over → stop per-point sends
+static bool     _clEndAcked  = false;        // end signal delivered to the server
+static const char* _clEndReason = "completed";
+static unsigned long _clEndTryMs = 0;        // last end-signal send attempt
 
 void cloudLogInit() {
   _clEnabled  = EEPROM.read(EEPROM_CLOUD_ENABLED) == 0x01;
@@ -29,7 +41,11 @@ void cloudLogNewFiring() {
   _clFiringId++;
   EEPROM.update(EEPROM_CLOUD_FIRING_ID,     (uint8_t)(_clFiringId & 0xFF));
   EEPROM.update(EEPROM_CLOUD_FIRING_ID + 1, (uint8_t)(_clFiringId >> 8));
-  _clLastMs = 0;
+  _clLastMs    = 0;
+  _clEnded     = false;
+  _clEndAcked  = false;
+  _clEndReason = "completed";
+  _clEndTryMs  = 0;
 }
 
 bool     cloudLogEnabled() { return _clEnabled; }
@@ -81,9 +97,75 @@ static void _clPost(uint16_t firingId, uint32_t sec, float temp, float sp,
 #endif
 }
 
+// Attempt to deliver the "firing ended" signal. Sets _clEndAcked on a successful
+// send; leaves it false (for retry) if WiFi/connect fails. Idempotent on the
+// server (UPSERT), so retries are harmless.
+static void _clSendEnd() {
+  if (_clEndAcked) return;
+  if (WiFi.status() != WL_CONNECTED) return;
+
+#ifndef CLOUD_LOG_HOST
+  _clEndAcked = true;                 // no cloud configured → nothing to retry
+  return;
+#else
+  WiFiSSLClient cl;
+  cl.setTimeout(3000);
+  if (!cl.connect(CLOUD_LOG_HOST, 443)) {
+    Serial.println(F("CL: end connect failed (will retry)"));
+    return;
+  }
+
+  char body[64];
+  int blen = snprintf(body, sizeof(body),
+    "{\"firing_id\":%u,\"reason\":\"%s\"}",
+    (unsigned)_clFiringId, _clEndReason);
+
+  cl.print(F("POST "));
+  cl.print(F(CLOUD_LOG_END_PATH));
+  cl.print(F(" HTTP/1.1\r\nHost: "));
+  cl.print(F(CLOUD_LOG_HOST));
+  cl.print(F("\r\nX-Kiln-Key: "));
+  cl.print(F(CLOUD_LOG_KEY));
+  cl.print(F("\r\nContent-Type: application/json\r\nConnection: close\r\nContent-Length: "));
+  cl.print(blen);
+  cl.print(F("\r\n\r\n"));
+  cl.print(body);
+
+  unsigned long t0 = millis();
+  while (!cl.available() && millis() - t0 < 2000 && cl.connected());
+  cl.stop();
+
+  _clEndAcked = true;
+  Serial.print(F("CL: ended #")); Serial.print(_clFiringId);
+  Serial.print(F(" reason=")); Serial.println(_clEndReason);
+#endif
+}
+
+// Mark the current firing as ended. Stops per-point sends immediately and
+// attempts the end signal once; cloudLogTick() retries if that attempt fails.
+// reason: "completed" | "stopped" | "estop". Safe to call more than once.
+void cloudLogEndFiring(const char* reason) {
+  if (!_clEnabled) return;
+  if (_clEnded)    return;            // already ended for this firing
+  _clEnded     = true;               // stop per-point sends from now on
+  _clEndReason = reason ? reason : "completed";
+  _clEndTryMs  = millis();
+  _clSendEnd();
+}
+
+// Periodic retry of an undelivered end signal. Call from loop(). Cheap no-op
+// unless a firing has ended but its end signal never reached the server.
+void cloudLogTick(unsigned long now) {
+  if (!_clEnabled || !_clEnded || _clEndAcked) return;
+  if (now - _clEndTryMs < CLOUD_LOG_END_RETRY_MS) return;
+  _clEndTryMs = now;
+  _clSendEnd();
+}
+
 void maybeSendCloudPoint(unsigned long now) {
   if (!_clEnabled) return;
   if (!firingStartMs) return;
+  if (_clEnded) return;
   if (WiFi.status() != WL_CONNECTED) return;
   if (_clLastMs != 0 && now - _clLastMs < CLOUD_LOG_INTERVAL_MS) return;
   _clLastMs = now;

--- a/firmware/moen_kiln/config_secrets.h.example
+++ b/firmware/moen_kiln/config_secrets.h.example
@@ -19,6 +19,7 @@
 // Copy these values from your Azure deployment. Leave undefined to disable.
 #define CLOUD_LOG_HOST          "miln-api.azurewebsites.net"
 #define CLOUD_LOG_PATH          "/api/log"
+#define CLOUD_LOG_END_PATH      "/api/firing-end"   // one-shot "firing ended" signal
 #define CLOUD_LOG_KEY           "change-me-strong-random-key"
 #define CLOUD_DASHBOARD_URL     "https://milncloud.moenadvisory.no"
 

--- a/firmware/moen_kiln/moen_kiln.ino
+++ b/firmware/moen_kiln/moen_kiln.ino
@@ -1,5 +1,5 @@
 // Moen Kiln – Arduino Uno R4 WiFi
-// 2026-06-13
+// 2026-06-24
 
 #include <SPI.h>
 #include <Adafruit_MAX31855.h>
@@ -186,6 +186,7 @@ void loop() {
     printStatus();
     logData();
     maybeSendCloudPoint(now);
+    cloudLogTick(now);
     tcLogTick(now);
     updateLED();
 
@@ -228,7 +229,9 @@ void tick() {
     Serial.println(F("=== CONFIG TEST: 4h timeout – sending report ==="));
     logEvent(EV_FERDIG);
     kilnState = COMPLETE; pidOutput = 0;
+    digitalWrite(PIN_RELAY, LOW);
     maybeSendReport();
+    cloudLogEndFiring("completed");
     return;
   }
   switch (kilnState) {
@@ -361,9 +364,11 @@ void nextSegment() {
   segIdx++;
   if (segIdx >= profile->segCount) {
     kilnState = COMPLETE; pidOutput = 0;
+    digitalWrite(PIN_RELAY, LOW);
     Serial.println(F("=== FIRING COMPLETE ==="));
     logEvent(EV_FERDIG);
     maybeSendReport();
+    cloudLogEndFiring("completed");
     return;
   }
   logEvent(EV_SEGMENT);
@@ -436,6 +441,7 @@ void triggerAlarm(const __FlashStringHelper* alarmMsg, uint8_t evType) {
   logEvent(evType);
   Serial.print(F("ALARM: ")); Serial.println(alarmMsg);
   maybeSendReport();
+  cloudLogEndFiring("estop");
 }
 
 // ── Nødstopp ──────────────────────────────────────────────────────────────────
@@ -456,6 +462,7 @@ void handleEstop() {
   kilnState = ESTOPPED;
   logEvent(EV_NODSTOPP);
   maybeSendReport();
+  cloudLogEndFiring("estop");
   estopFlag = false; estopAnnounced = false;
   kilnState = IDLE; pidI = 0; setpoint = 0;
   stoppedMs = millis();
@@ -728,8 +735,10 @@ void checkStartButton() {
       drawCancelCountdown(min(1.0f, (float)(held - 500) / 4500.0f));
       if (held >= 5000) {
         cancelHeld = false; holdStart = 0;
+        digitalWrite(PIN_RELAY, LOW);
         logEvent(EV_AVBRYT);
         maybeSendReport();
+        cloudLogEndFiring("stopped");
         estopFlag = false; estopAnnounced = false;
         kilnState = IDLE; pidOutput = 0; pidI = 0; setpoint = 0;
         showingIP = false;
@@ -1096,16 +1105,19 @@ void handleHTTP() {
 
   } else if (req.startsWith("POST /api/stop")) {
     if (kilnState != IDLE) {
-      maybeSendReport();
-      logEvent(EV_AVBRYT);
       digitalWrite(PIN_RELAY, LOW);
+      maybeSendReport();
+      cloudLogEndFiring("stopped");
+      logEvent(EV_AVBRYT);
       kilnState = IDLE; pidOutput = 0; pidI = 0; setpoint = 0;
       stoppedMs = millis();
     }
     httpOK(client, "application/json"); client.print(F("{\"ok\":true}"));
 
   } else if (req.startsWith("POST /api/reset")) {
+    digitalWrite(PIN_RELAY, LOW);
     maybeSendReport();
+    if (kilnState != IDLE) cloudLogEndFiring("stopped");
     estopFlag = false; estopAnnounced = false;
     kilnState = IDLE; pidOutput = 0; pidI = 0; setpoint = 0;
     matrixClear();
@@ -1189,10 +1201,12 @@ void handleSerial() {
   } else if (cmd == "relay off") {
     manualRelay = false; Serial.println(F("Relay: OFF"));
   } else if (cmd == "stop")    {
-    if (kilnState != IDLE) { maybeSendReport(); logEvent(EV_AVBRYT); digitalWrite(PIN_RELAY, LOW); kilnState = IDLE; pidOutput = 0; pidI = 0; setpoint = 0; stoppedMs = millis(); }
+    if (kilnState != IDLE) { digitalWrite(PIN_RELAY, LOW); maybeSendReport(); cloudLogEndFiring("stopped"); logEvent(EV_AVBRYT); kilnState = IDLE; pidOutput = 0; pidI = 0; setpoint = 0; stoppedMs = millis(); }
     Serial.println(F("Stopped"));
   } else if (cmd == "reset")   {
+    digitalWrite(PIN_RELAY, LOW);
     maybeSendReport();
+    if (kilnState != IDLE) cloudLogEndFiring("stopped");
     estopFlag = false; estopAnnounced = false;
     kilnState = IDLE; pidOutput = 0; pidI = 0; setpoint = 0;
     matrixClear();


### PR DESCRIPTION
Implements three approved MilnCloudLog features. Firmware compiles clean (57% flash / 62% RAM); a high-effort multi-agent code review ran and all 10 confirmed findings were fixed before this PR (relay-before-blocking-I/O safety ordering, end-signal retry/ack, status time-window, and endpoint input validation).

## #75 — Download firing log as CSV
- Client-side "⬇ Last ned CSV" button on the firing detail view. Columns `ts,sec_elapsed,temp_c,setpoint_c,relay,duty_pct,segment,is_err`; filename `brenning-{id}-{date}.csv`. No backend change.

## #76 — Stop logging + clear LIVE when a firing ends
- **Firmware:** `cloudLogEndFiring(reason)` stops per-point sends and delivers a one-shot end signal; `cloudLogTick()` retries until acked so a momentary WiFi drop at firing-end no longer loses the signal. Relay is driven **LOW before** any blocking network call on every stop/abort path (web, serial, button, e-stop, complete).
- **Cloud:** new `firing_meta` table (migration `002_firing_meta.sql`), idempotent `POST /api/firing-end` (UPSERT, strict `firing_id`/`reason` validation), `firings` LEFT JOINs it.
- **Dashboard:** explicit `✓ Fullført` / `■ Stoppet` / `⚠ Nødstopp`, plus `● LIVE` and a time-bounded `⚠ Frakoblet`; old history stays neutral.

## #77 — Chart zoom/pan
- `chartjs-plugin-zoom` (+ hammerjs) on the firing and TC charts: wheel, drag-pan, pinch on mobile, with a "Tilbakestill zoom" button each.

## Deploy notes (manual, after merge)
1. Run `cloud/function/sql/002_firing_meta.sql` against the `miln` database (creates table + GRANT). Additive/online.
2. Deploy `miln-api` via the `WEBSITE_RUN_FROM_PACKAGE` blob-SAS package pattern (new `firing-end` function).
3. Static Web App `miln-web` picks up `dashboard.html`.
4. Flash firmware; ensure `config_secrets.h` has `CLOUD_LOG_END_PATH` (defaults to `/api/firing-end`).

## GDPR
No new surface returns personal data — `/api/firing-end` writes only firing metadata; `/api/firings` remains firing metadata behind the existing Bearer auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)