### PR TITLE
TC gain calibration + ceiling plateau / heating-fault handling (#81, #83)

### DIFF
--- a/firmware/moen_kiln/config.h
+++ b/firmware/moen_kiln/config.h
@@ -36,6 +36,8 @@ struct DataPoint { uint16_t sec; uint16_t temp; uint16_t sp; uint8_t segIdx; uin
 #define EV_NODSTOPP     5   // Nødstopp
 #define EV_FERDIG       6   // Brenning ferdig
 #define EV_AVBRYT       7   // Avbrutt av bruker
+#define EV_PLATEAU      8   // Tak nådd (platå) – avanserte programmet
+#define EV_ERR_NOHEAT   9   // FEIL: Temp synker ved full effekt
 struct Event { uint16_t sec; uint8_t type; uint16_t temp; };
 
 // ── Webserver ────────────────────────────────────────────────────────────────
@@ -51,8 +53,27 @@ struct Event { uint16_t sec; uint8_t type; uint16_t temp; };
 #define RELAY_WINDOW_MS  30000UL
 #define RELAY_MIN_ON_MS  3000UL   // kortere pulser droppes – unngår rask relé-sykling (10 % av vindu)
 
+// ── Termoelement-kalibrering ───────────────────────────────────────────────────
+// MAX31855 reads ~4.5 % low at high temperature (cone-derived, see issue #81/#78):
+// bisque cone 05 (1046C) vs displayed 1000.5C, glaze cone 6 (1222C) vs 1169.5C →
+// both give gain ~1.045, and ~0 error at room temp → multiplicative correction.
+// corrected = raw * TC_GAIN. Validate with a witness cone before fully trusting.
+#define TC_GAIN          1.045f
+
 // ── Sikkerhet ────────────────────────────────────────────────────────────────
 #define MAX_TEMP_C       1300.0f
+
+// Ceiling plateau (issue #83): if the kiln drives near full power but temperature
+// stops rising, treat the target as "reached" and advance the program instead of
+// hanging forever. Resets whenever temp climbs >= STALL_RISE_C.
+#define STALL_RISE_C     3.0f       // min rise to count as "still climbing"
+#define STALL_WINDOW_MS  900000UL   // 15 min flat at high duty → plateau
+#define STALL_MIN_DUTY   90.0f      // only evaluate when driving this hard (%)
+
+// Heating fault (issue #83): temperature falling while driving at full power =
+// dead element / relay / open door → alarm. Conservative to avoid false positives.
+#define NOHEAT_DROP_C    15.0f
+#define NOHEAT_WINDOW_MS 600000UL   // 10 min
 
 // ── EEPROM-layout ─────────────────────────────────────────────────────────────
 // E-post konfigurasjon

--- a/firmware/moen_kiln/moen_kiln.ino
+++ b/firmware/moen_kiln/moen_kiln.ino
@@ -1,5 +1,5 @@
 // Moen Kiln – Arduino Uno R4 WiFi
-// 2026-06-24
+// 2026-06-24  TC gain calibration (#81) + ceiling plateau / heating-fault handling (#83)
 
 #include <SPI.h>
 #include <Adafruit_MAX31855.h>
@@ -36,6 +36,12 @@ uint8_t         segIdx       = 0;
 float           segStartTemp = 0.0f;
 unsigned long   segStartMs   = 0;
 unsigned long   holdStartMs  = 0;
+
+// Ceiling-plateau & heating-fault tracking (issue #83). 0 ms = uninitialised.
+float           stallRefTemp  = 0.0f;
+unsigned long   stallRefMs    = 0;
+float           noHeatRefTemp = 0.0f;
+unsigned long   noHeatRefMs   = 0;
 
 // ── PID ───────────────────────────────────────────────────────────────────────
 float setpoint   = 0.0f;
@@ -216,7 +222,7 @@ void readTemp() {
     triggerAlarm(F("Thermocouple error"));
 
   if (valid) {
-    currentTemp = (float)t;
+    currentTemp = (float)t * TC_GAIN;  // cone-derived calibration, see config.h / #81
     if (currentTemp > peakTemp) peakTemp = currentTemp;
   }
 }
@@ -259,7 +265,25 @@ void tickRamping() {
   if (setpoint == seg.targetTemp) {
     bool atTarget = rampUp ? (currentTemp >= seg.targetTemp - 2.0f)
                            : (currentTemp <= seg.targetTemp + 2.0f);
-    if (atTarget) {
+
+    // Ceiling plateau (#83): on an up-ramp, if the kiln drives near full power
+    // but temperature has stopped rising, treat the target as reached so the
+    // firing advances instead of hanging forever. Window resets while climbing.
+    bool plateau = false;
+    if (rampUp && !atTarget) {
+      if (stallRefMs == 0 || currentTemp >= stallRefTemp + STALL_RISE_C) {
+        stallRefMs = millis(); stallRefTemp = currentTemp;   // (re)start window
+      } else if (pidOutput >= STALL_MIN_DUTY &&
+                 millis() - stallRefMs >= STALL_WINDOW_MS) {
+        plateau = true;
+        logEvent(EV_PLATEAU);
+        Serial.print(F("Plateau at ceiling (")); Serial.print(currentTemp, 0);
+        Serial.print(F("C / target ")); Serial.print(seg.targetTemp, 0);
+        Serial.println(F("C) – advancing"));
+      }
+    }
+
+    if (atTarget || plateau) {
       if (seg.holdMin > 0) {
         kilnState = HOLDING; holdStartMs = millis();
         logEvent(EV_HOLD);
@@ -379,6 +403,8 @@ void startSegment() {
   const Segment& seg = profile->segments[segIdx];
   segStartTemp = currentTemp;
   segStartMs   = millis();
+  stallRefMs   = 0;   // reset plateau/heating-fault windows for the new segment (#83)
+  noHeatRefMs  = 0;
   setpoint = segStartTemp;
   Serial.print(F("Segment: ")); Serial.print(seg.name);
   Serial.print(F("  Target: ")); Serial.print(seg.targetTemp, 0); Serial.println(F("C"));
@@ -434,6 +460,20 @@ void updateStatusLED() {
 // ── Alarmer ───────────────────────────────────────────────────────────────────
 void checkAlarms() {
   if (currentTemp > MAX_TEMP_C) triggerAlarm(F("Max temperature exceeded"), EV_ERR_MAXTEMP);
+
+  // Heating fault (#83): if we drive near full power but temperature *falls*
+  // and stays down, the heating chain has failed (element / relay / open door).
+  // A flat plateau is handled separately in tickRamping; only a real drop alarms.
+  if (pidOutput >= STALL_MIN_DUTY) {
+    if (noHeatRefMs == 0 || currentTemp >= noHeatRefTemp) {
+      noHeatRefMs = millis(); noHeatRefTemp = currentTemp;   // new high → reset
+    } else if (currentTemp <= noHeatRefTemp - NOHEAT_DROP_C &&
+               millis() - noHeatRefMs >= NOHEAT_WINDOW_MS) {
+      triggerAlarm(F("Heating fault: temperature falling at full power"), EV_ERR_NOHEAT);
+    }
+  } else {
+    noHeatRefMs = 0;   // not driving hard → don't evaluate
+  }
 }
 
 void triggerAlarm(const __FlashStringHelper* alarmMsg, uint8_t evType) {
@@ -494,6 +534,8 @@ const char* eventStr(uint8_t t) {
     case EV_NODSTOPP:   return "Emergency stop";
     case EV_FERDIG:     return "Firing complete";
     case EV_AVBRYT:     return "Cancelled by user";
+    case EV_PLATEAU:    return "Ceiling reached (advanced)";
+    case EV_ERR_NOHEAT: return "ERR: Temperature falling at full power";
     default:            return "Unknown";
   }
 }


### PR DESCRIPTION
## What & why
Two changes from the firing analysis in #78, done together because the first makes the second necessary.

### #81 — Thermocouple gain calibration
Cone evidence (two firings) shows the MAX31855 reads **~4.5 % low at high temp**, ~0 error at room temp → a multiplicative **gain** error, not an offset:

| Reference | true/cone | TC displayed | gain |
|---|---|---|---|
| Bisque, cone 05 half-bent | 1046 | 1000.5 | 1.046 |
| Glaze, cone 6 | ~1222 | 1169.5 | 1.045 |
| Room temp | 22 | 21.5 | ~1.0 |

→ `currentTemp = raw * TC_GAIN` (1.045). `MAX_TEMP_C=1300` keeps margin (real 1300 trips at displayed ~1244).

### #83 — Ramp completion: plateau-advance + heating-fault
`tickRamping` only advanced at `target − 2 °C`, so a setpoint at the kiln's ceiling (cone-6 glaze 1222) would **hang at 100 % duty forever** — exactly what forced the manual stop in #78. Calibration makes this acute.

- **Plateau → hold:** up-ramp + duty ≥ `STALL_MIN_DUTY` + rise < `STALL_RISE_C` over `STALL_WINDOW_MS` → enter the programmed hold at the plateau temp. Advances *below* target → cannot overfire (cf. #74).
- **Heating fault → stop:** temp *falling* ≥ `NOHEAT_DROP_C` at full power for `NOHEAT_WINDOW_MS` → alarm (dead element/relay/open door).
- New events `EV_PLATEAU`, `EV_ERR_NOHEAT`.

## Validation
- ✅ Compiles for Uno R4 WiFi (57 % flash, 62 % RAM).
- ✅ Thresholds checked against the #78 glaze log (plateau ~0.15 °C/min near top → triggers correctly).
- ⏳ **On-kiln:** next firing should carry a **witness cone** to confirm the 1.045 gain, and profile target temps should be re-confirmed against cones (everything fires ~4–5 % cooler at the same setpoint now). Thresholds in `config.h` are conservative starting points, tune on real firings.

## Notes
- Heating-fault detection (#83 part B) is net-new safety (there was none before). Conservative thresholds to avoid false positives (peephole etc.) — flag if you'd rather drop it.
- Related top-end capacity observation tracked separately in #82.

Closes #81, closes #83. Refs #78, #82, #74.
