### PR TITLE
Controlled cooling: PID drives elements on descending ramps (#85)

### DIFF
--- a/firmware/moen_kiln/moen_kiln.ino
+++ b/firmware/moen_kiln/moen_kiln.ino
@@ -1,4 +1,5 @@
 // Moen Kiln – Arduino Uno R4 WiFi
+// 2026-06-30  Controlled cooling: PID drives elements on descending ramps (#85)
 // 2026-06-30  Log UI: newest entry first + 4 min auto-refresh (#86)
 // 2026-06-24  TC gain calibration (#81) + ceiling plateau / heating-fault handling (#83)
 
@@ -294,7 +295,11 @@ void tickRamping() {
     }
   }
 
-  pidOutput = (!rampUp && currentTemp <= setpoint) ? 0 : computePID(setpoint, currentTemp);
+  // Controlled cooling (#85): a descending ramp must drive the elements to hold
+  // the programmed cooling rate, exactly like an up-ramp. computePID returns 0 on
+  // its own when the kiln is above setpoint (cooling too slow), so no direction
+  // special-case is needed here. Pure free-fall stays in FREE_COOL (rate == 0).
+  pidOutput = computePID(setpoint, currentTemp);
   checkAlarms();
 }
 
@@ -406,6 +411,8 @@ void startSegment() {
   segStartMs   = millis();
   stallRefMs   = 0;   // reset plateau/heating-fault windows for the new segment (#83)
   noHeatRefMs  = 0;
+  pidI = 0.0f; pidLastErr = 0.0f;  // clear integral so a saturated up-ramp doesn't
+                                   // fire elements into the following cool (#85)
   setpoint = segStartTemp;
   Serial.print(F("Segment: ")); Serial.print(seg.name);
   Serial.print(F("  Target: ")); Serial.print(seg.targetTemp, 0); Serial.println(F("C"));
@@ -465,7 +472,11 @@ void checkAlarms() {
   // Heating fault (#83): if we drive near full power but temperature *falls*
   // and stays down, the heating chain has failed (element / relay / open door).
   // A flat plateau is handled separately in tickRamping; only a real drop alarms.
-  if (pidOutput >= STALL_MIN_DUTY) {
+  // Skip during a controlled cool (#85): there the temperature is *meant* to fall
+  // while the elements fire to hold the rate, which would otherwise false-trigger.
+  bool descendingRamp = (kilnState == RAMPING &&
+                         profile->segments[segIdx].targetTemp < segStartTemp);
+  if (!descendingRamp && pidOutput >= STALL_MIN_DUTY) {
     if (noHeatRefMs == 0 || currentTemp >= noHeatRefTemp) {
       noHeatRefMs = millis(); noHeatRefTemp = currentTemp;   // new high → reset
     } else if (currentTemp <= noHeatRefTemp - NOHEAT_DROP_C &&
@@ -1319,7 +1330,10 @@ void startProfile(const Profile* p) {
 const char* stateStr() {
   switch (kilnState) {
     case IDLE:      return "IDLE";
-    case RAMPING:   return "RAMP";
+    // A descending ramp is a controlled cool, not a heat-up (#85): report it as
+    // COOL so the UI shows "Cooling down" instead of "Heating up".
+    case RAMPING:   return (profile->segments[segIdx].targetTemp < segStartTemp)
+                             ? "COOL" : "RAMP";
     case HOLDING:   return "HOLD";
     case FREE_COOL: return "COOL";
     case COMPLETE:  return "DONE";


### PR DESCRIPTION
Fixes #85.

## What
Make descending (cooling) ramp segments actually hold their programmed cooling rate by letting the PID drive the elements on the way down, instead of free-falling.

## Why
In firing #15 the profile's segment 5 (70 C/h slow cool, 1000 -> 760C, a standard cone-6 glaze technique) collapsed into ~10 min of free-fall: the controller forced duty to 0 whenever the kiln dropped below the cooling setpoint, so it never fired the elements to slow the descent.

## Changes (firmware/moen_kiln/moen_kiln.ino)
1. tickRamping: always run computePID on a ramp. It already returns 0 when the kiln is above setpoint (cooling too slow), so no direction special-case is needed; the old (!rampUp && currentTemp <= setpoint) ? 0 clause that blocked heating on descent is gone.
2. checkAlarms: skip the heating-fault alarm during a descending ramp, where the temperature is meant to fall while the elements fire to hold the rate (otherwise it would false-trigger and E-stop the cool). MAX_TEMP_C and the hold-phase check are unchanged.
3. startSegment: clear the PID integral (pidI, pidLastErr) per segment so a saturated up-ramp doesn't fire the elements into the start of the following cool (windup).
4. stateStr: a descending ramp now reports COOL, so both the device web UI and the cloud badge show Cooling down instead of the wrong Heating up.

FREE_COOL (rate == 0) is unchanged and remains pure free-fall.

## Verification
- arduino-cli compile passes (57% flash, memory unchanged).
- GDPR: N/A, firmware only, no endpoints returning user data.
- Real-world validation requires a glaze firing: confirm duty > 0 and relay cycling during the slow-cool segment, and that temperature tracks the descending setpoint.

Generated with Claude Code