### PR TITLE
Runtime-configurable thermocouple gain via web UI (#88)

### DIFF
--- a/firmware/moen_kiln/config.h
+++ b/firmware/moen_kiln/config.h
@@ -58,7 +58,11 @@ struct Event { uint16_t sec; uint8_t type; uint16_t temp; };
 // bisque cone 05 (1046C) vs displayed 1000.5C, glaze cone 6 (1222C) vs 1169.5C →
 // both give gain ~1.045, and ~0 error at room temp → multiplicative correction.
 // corrected = raw * TC_GAIN. Validate with a witness cone before fully trusting.
+// This is the factory default; the live value is runtime-configurable and persisted
+// in EEPROM (#88), so it can be re-trimmed after a cone check without reflashing.
 #define TC_GAIN          1.045f
+#define TC_GAIN_MIN      0.90f      // clamp range for the runtime gain – reject outside
+#define TC_GAIN_MAX      1.15f
 
 // ── Sikkerhet ────────────────────────────────────────────────────────────────
 #define MAX_TEMP_C       1300.0f
@@ -106,7 +110,11 @@ struct Event { uint16_t sec; uint8_t type; uint16_t temp; };
 // Cloud logging
 #define EEPROM_CLOUD_ENABLED    6351    // 1 byte : 0x01 = cloud logging on
 #define EEPROM_CLOUD_FIRING_ID  6352    // 2 bytes: uint16_t persistent firing counter
-// 6354 onwards: free  (8192 bytes total EEPROM)
+
+// Thermocouple gain calibration (runtime-configurable, #88)  0x47 = valid
+#define EEPROM_TCGAIN_FLAG      6354    // 1 byte : 0x47 = runtime gain stored
+#define EEPROM_TCGAIN_VAL       6355    // 4 bytes: float TC gain → ends at 6359
+// 6359 onwards: free  (8192 bytes total EEPROM)
 
 // Custom firing profiles (user-editable; default profiles are compile-time constants)  0x46 = valid
 #define MAX_CUSTOM_PROFILES    5

--- a/firmware/moen_kiln/moen_kiln.ino
+++ b/firmware/moen_kiln/moen_kiln.ino
@@ -1,4 +1,5 @@
 // Moen Kiln – Arduino Uno R4 WiFi
+// 2026-06-30  Runtime-configurable TC gain via web UI, persisted in EEPROM (#88)
 // 2026-06-30  Log UI: newest entry first + 4 min auto-refresh (#86)
 // 2026-06-24  TC gain calibration (#81) + ceiling plateau / heating-fault handling (#83)
 
@@ -30,6 +31,7 @@ State kilnState = IDLE;
 float currentTemp = 0.0f;
 float prevTemp    = 0.0f;   // forrige avlesning for delta-beregning
 float peakTemp    = 0.0f;   // høyeste temperatur i denne brenningen
+float tcGain      = TC_GAIN; // live TC gain; default fra config.h, overstyres fra EEPROM (#88)
 
 // ── Aktiv profil ──────────────────────────────────────────────────────────────
 const Profile*  profile      = nullptr;
@@ -156,6 +158,7 @@ void setup() {
 
   loadPersistentLog();
   loadCustomProfiles();
+  loadTcGain();
   setupWiFi();
   cloudLogInit();
 
@@ -203,6 +206,21 @@ void loop() {
   updateStatusLED();
 }
 
+// ── TC gain-kalibrering (runtime, #88) ────────────────────────────────────────
+void loadTcGain() {
+  if (EEPROM.read(EEPROM_TCGAIN_FLAG) == 0x47) {
+    float g; EEPROM.get(EEPROM_TCGAIN_VAL, g);
+    if (g >= TC_GAIN_MIN && g <= TC_GAIN_MAX) { tcGain = g; return; }
+  }
+  tcGain = TC_GAIN;   // fersk enhet eller ugyldig lagret verdi → fabrikkstandard
+}
+
+void saveTcGain(float g) {
+  tcGain = constrain(g, TC_GAIN_MIN, TC_GAIN_MAX);
+  EEPROM.put(EEPROM_TCGAIN_VAL, tcGain);
+  EEPROM.update(EEPROM_TCGAIN_FLAG, 0x47);
+}
+
 // ── Temperaturlesing ──────────────────────────────────────────────────────────
 void readTemp() {
   double t = tc.readCelsius();
@@ -223,7 +241,7 @@ void readTemp() {
     triggerAlarm(F("Thermocouple error"));
 
   if (valid) {
-    currentTemp = (float)t * TC_GAIN;  // cone-derived calibration, see config.h / #81
+    currentTemp = (float)t * tcGain;  // runtime cone-derived calibration, see config.h / #81 / #88
     if (currentTemp > peakTemp) peakTemp = currentTemp;
   }
 }
@@ -1189,6 +1207,29 @@ void handleHTTP() {
     if (newKey.length())  strncpy(key, newKey.c_str(),  49);
     saveEmailConfig(key, to, cc, frm);
     httpOK(client, "application/json"); client.print(F("{\"ok\":true}"));
+
+  } else if (req.startsWith("GET /api/tcgain")) {
+    httpOK(client, "application/json");
+    client.print(F("{\"gain\":"));    client.print(tcGain, 4);
+    client.print(F(",\"default\":")); client.print((float)TC_GAIN, 4);
+    client.print(F(",\"min\":"));     client.print((float)TC_GAIN_MIN, 3);
+    client.print(F(",\"max\":"));     client.print((float)TC_GAIN_MAX, 3);
+    client.print(F(",\"idle\":"));    client.print(kilnState == IDLE ? "true" : "false");
+    client.print('}');
+
+  } else if (req.startsWith("POST /api/tcgain")) {
+    httpOK(client, "application/json");
+    if (kilnState != IDLE) {
+      client.print(F("{\"ok\":false,\"error\":\"not idle\"}"));   // avoid mid-firing jump
+    } else {
+      float g = formParam(body, "gain").toFloat();
+      if (g < TC_GAIN_MIN || g > TC_GAIN_MAX) {
+        client.print(F("{\"ok\":false,\"error\":\"out of range\"}"));
+      } else {
+        saveTcGain(g);
+        client.print(F("{\"ok\":true,\"gain\":")); client.print(tcGain, 4); client.print('}');
+      }
+    }
 
   } else if (req.startsWith("GET /api/cloudlog")) {
     httpOK(client, "application/json");

--- a/firmware/moen_kiln/web_ui.h
+++ b/firmware/moen_kiln/web_ui.h
@@ -74,6 +74,10 @@ input:checked+.tsl:before{transform:translateX(16px);background:#fff}
 <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:10px">
   <h1 style="margin:0">🔥 Moen Kiln</h1>
   <div style="display:flex;gap:14px;align-items:center">
+    <div class="trow" style="margin:0" title="Thermocouple gain calibration (edit in Settings)">
+      <span class="trow-label">Gain</span>
+      <span class="trow-status" id="tcgain-top">--</span>
+    </div>
     <div class="trow" style="margin:0">
       <span class="trow-label">TC log</span>
       <label class="tgl"><input type="checkbox" id="tc-toggle" onchange="toggleTcLog(this.checked)"><span class="tsl"></span></label>
@@ -194,6 +198,13 @@ input:checked+.tsl:before{transform:translateX(16px);background:#fff}
 <input class="inp" id="efrom" type="email" placeholder="From: miln@your-domain.com">
 <input class="inp" id="ekey" type="password" placeholder="Resend API key (leave blank to keep existing)">
 <button class="go" style="width:100%" onclick="saveSet()">Save settings</button>
+<p class="shead" style="margin-top:14px">🌡️ Thermocouple gain</p>
+<p style="font-size:.78em;color:#888;margin:0 0 6px">Multiplicative calibration (corrected = raw × gain). Re-trim after a witness-cone check. Only editable when idle.</p>
+<div style="display:flex;gap:8px;align-items:center">
+  <input class="inp" id="tcgain" type="number" step="0.001" style="margin:0" placeholder="1.045">
+  <button class="go" id="btn-savegain" style="flex:0 0 auto;padding:10px 14px" onclick="saveGain()">Save</button>
+</div>
+<div id="tcgain-info" style="font-size:.78em;color:#888;margin-top:4px;min-height:1.1em"></div>
 </div>
 </details>
 </div>
@@ -390,6 +401,26 @@ function saveSet(){
     +'&key='+encodeURIComponent(document.getElementById('ekey').value);
   fetch('/api/settings',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:b})
     .then(function(){alert('Saved!');});
+}
+function loadGain(){
+  fetch('/api/tcgain').then(function(r){return r.json();}).then(function(d){
+    document.getElementById('tcgain-top').textContent=Number(d.gain).toFixed(3);
+    var inp=document.getElementById('tcgain');
+    inp.value=Number(d.gain).toFixed(3);inp.min=d.min;inp.max=d.max;
+    document.getElementById('btn-savegain').disabled=!d.idle;
+    document.getElementById('tcgain-info').textContent=
+      'Range '+d.min+'–'+d.max+', default '+Number(d.default).toFixed(3)+(d.idle?'':' · locked (firing in progress)');
+  }).catch(function(){});
+}
+function saveGain(){
+  var v=parseFloat(document.getElementById('tcgain').value);
+  if(isNaN(v)){alert('Enter a number');return;}
+  if(!confirm('Change thermocouple gain to '+v.toFixed(3)+'?\n\nWrong values can over- or under-fire the kiln.'))return;
+  fetch('/api/tcgain',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:'gain='+encodeURIComponent(v)})
+    .then(function(r){return r.json();}).then(function(d){
+      if(d.ok){loadGain();alert('Saved! Gain = '+Number(d.gain).toFixed(3));}
+      else alert('Not saved: '+(d.error==='not idle'?'kiln must be idle':d.error==='out of range'?'value out of range':d.error||'unknown'));
+    }).catch(function(){alert('Save failed');});
 }
 // ── Profile editor ────────────────────────────────────────────────────────────
 var allProfiles=[];
@@ -656,6 +687,7 @@ loadProfiles();
 poll();
 refreshLog();
 refreshCloud();
+loadGain();
 setInterval(refreshLog, 240000);
 </script>
 </body>


### PR DESCRIPTION
Fixes #88.

## What
Make the thermocouple calibration factor (`TC_GAIN`) runtime-configurable and EEPROM-persisted, so it can be re-trimmed after a witness-cone check without reflashing. Pre-filled with the current value.

## Changes
**config.h**
- `TC_GAIN` (1.045) stays as the factory default / reset fallback.
- Add `TC_GAIN_MIN` / `TC_GAIN_MAX` (0.90–1.15) clamp range.
- Add EEPROM slot after the cloud block: `EEPROM_TCGAIN_FLAG` (6354, 0x47) + `EEPROM_TCGAIN_VAL` (6355, float) → ends 6359, well within the 8192-byte EEPROM.

**moen_kiln.ino**
- Global `tcGain`, loaded from EEPROM at boot via `loadTcGain()` (falls back to the config.h default if unset or out of range).
- `readTemp()` uses the live `tcGain` instead of the `#define`.
- `saveTcGain()` clamps + persists.
- `GET /api/tcgain` returns `{gain, default, min, max, idle}`; `POST /api/tcgain` validates range and is rejected unless the kiln is IDLE.

**web_ui.h**
- Read-only **Gain** indicator in the top menu (per request — visible at a glance).
- Editable field in Settings, pre-filled, with a confirmation dialog; the Save button locks while a firing is in progress.

## Safety
- Hard range clamp (reject + constrain).
- Idle-only edits — no mid-firing jump in the measured temperature.
- Confirmation dialog (a wrong gain can over/under-fire).
- config.h default remains the fallback.

## Verification
- `arduino-cli compile` passes (60% flash).
- GDPR: N/A — firmware only, no endpoints returning user data.
- Ties into tonight's cone reading: if cone 6 bent, set the gain to ~1.065 straight from the web UI instead of reflashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)