### PR TITLE
Add Iris lustre and Heating built-in profiles (#90)

### DIFF
--- a/firmware/moen_kiln/moen_kiln.ino
+++ b/firmware/moen_kiln/moen_kiln.ino
@@ -1,4 +1,5 @@
 // Moen Kiln – Arduino Uno R4 WiFi
+// 2026-07-01  Add built-in profiles: Iris lustre + Heating (#90)
 // 2026-06-30  Runtime-configurable TC gain via web UI, persisted in EEPROM (#88)
 // 2026-06-30  Controlled cooling: PID drives elements on descending ramps (#85)
 // 2026-06-30  Log UI: newest entry first + 4 min auto-refresh (#86)

--- a/firmware/moen_kiln/profiles.h
+++ b/firmware/moen_kiln/profiles.h
@@ -30,6 +30,20 @@ static const Segment SEG_BISQUE[] = {
   { "Bisque 2", 995,  150, 15 },
 };
 
+// ── Iris lustre ───────────────────────────────────────────────────────────────
+// Oxidation, low-temp lustre firing. Peephole/valve may be open up to ~450–500 °C.
+static const Segment SEG_IRISLUSTRE[] = {
+  { "Iris 1", 200,  90, 0  },
+  { "Iris 2", 400,  60, 10 },
+  { "Iris 3", 770, 120, 5  },
+};
+
+// ── Heating ───────────────────────────────────────────────────────────────────
+// Oxidation, warm ceramics up for reglazing.
+static const Segment SEG_HEATING[] = {
+  { "Heating 1", 70, 150, 10 },
+};
+
 // ── Config test: max speed to 1220 °C, then free cool to room temp ────────────
 static const Segment SEG_CONFIGTEST[] = {
   { "Ramp Up",    800, 9999, 0 },
@@ -37,8 +51,10 @@ static const Segment SEG_CONFIGTEST[] = {
 };
 
 static const Profile PROFILES[] = {
-  { "glaze",      "Glaze",       5, SEG_GLAZE      },
+  { "glaze",      "Glaze",       5, SEG_GLAZE       },
   { "bisque",     "Bisque",      2, SEG_BISQUE      },
+  { "irislustre", "Iris lustre", 3, SEG_IRISLUSTRE  },
+  { "heating",    "Heating",     1, SEG_HEATING     },
   { "configtest", "Config Test", 2, SEG_CONFIGTEST  },
 };
 


### PR DESCRIPTION
Fixes #90.

Adds two built-in (compile-time) firing profiles to `firmware/moen_kiln/profiles.h`, alongside Glaze and Bisque. Both oxidation, start 20°C. They appear automatically in the profile list / start dropdown.

## Iris lustre (low-temp lustre firing, ~8:40)
| Seg | °C/h | Target °C | Hold (min) |
|-----|------|-----------|------------|
| 1 | 90 | 200 | 0 |
| 2 | 60 | 400 | 10 |
| 3 | 120 | 770 | 5 |

## Heating (warm ceramics for reglazing, 0:30)
| Seg | °C/h | Target °C | Hold (min) |
|-----|------|-----------|------------|
| 1 | 150 | 70 | 10 |

## Notes
- Placed after Bisque, before the hidden Config Test profile.
- The built-in `Profile`/`Segment` structs have no cone or free-text note field, so the templates' blank Orton cone and their descriptions ('peephole/valve open up to ~450–500°C'; 'for heating up ceramics to be reglazed') are operational info only, not stored in firmware.
- `arduino-cli compile` passes (61% flash). GDPR: N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)